### PR TITLE
Load/unload units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -43,7 +43,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -137,7 +137,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -353,10 +353,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -508,12 +555,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
@@ -524,6 +610,7 @@ dependencies = [
  "cursive",
  "futures",
  "lazy_static",
+ "notify",
  "plist",
  "tokio",
  "xpc-sys",
@@ -554,7 +641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
  "cc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -604,15 +691,58 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow 0.2.2",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
 dependencies = [
  "libc",
  "log",
- "miow",
+ "miow 0.3.6",
  "ntapi",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio 0.6.23",
+ "slab",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
@@ -622,7 +752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -637,6 +767,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,12 +788,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "4.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2599080e87c9bd051ddb11b10074f4da7b1223298df65d4c2ec5bcf309af1533"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio 0.6.23",
+ "mio-extras",
+ "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -765,7 +924,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -882,6 +1041,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,7 +1106,7 @@ checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -977,7 +1145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1014,7 +1182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1036,14 +1204,14 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.7.9",
  "num_cpus",
  "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1097,6 +1265,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1292,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -1120,6 +1305,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1133,7 +1324,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1141,6 +1332,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
 
 [[package]]
 name = "xcrun"

--- a/launchk/Cargo.toml
+++ b/launchk/Cargo.toml
@@ -14,3 +14,4 @@ tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 plist = "1.1.0"
 bitflags = "1.2.1"
+notify = "4.0.16"

--- a/launchk/src/launchd/config.rs
+++ b/launchk/src/launchd/config.rs
@@ -6,8 +6,14 @@ use std::path::Path;
 use std::sync::{Mutex, Once};
 
 use crate::tui::job_type_filter::JobTypeFilter;
+use std::fs::{DirEntry, ReadDir};
+use tokio::runtime::Handle;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use notify::{watcher, DebouncedEvent, Watcher, RecursiveMode};
+use std::time::Duration;
+use std::iter::FilterMap;
 
-static LABEL_MAP_INIT: Once = Once::new();
+pub static LABEL_MAP_INIT: Once = Once::new();
 
 lazy_static! {
     static ref LABEL_TO_PLIST: Mutex<HashMap<String, LaunchdEntryConfig>> =
@@ -79,10 +85,122 @@ pub const SYSTEM_LAUNCH_AGENTS: &str = "/System/Library/LaunchAgents";
 pub const ADMIN_LAUNCH_DAEMONS: &str = "/Library/LaunchDaemons";
 pub const GLOBAL_LAUNCH_DAEMONS: &str = "/System/Library/LaunchDaemons";
 
+async fn fsnotify_subscriber() {
+    let (tx, rx): (Sender<DebouncedEvent>, Receiver<DebouncedEvent>) = channel();
+    let mut watcher = watcher(tx, Duration::from_secs(5))
+        .expect("Must make fsnotify watcher");
+
+    // Register plist paths
+    let watchers = [
+        watcher.watch(Path::new(USER_LAUNCH_AGENTS), RecursiveMode::Recursive),
+        watcher.watch(Path::new(GLOBAL_LAUNCH_AGENTS), RecursiveMode::Recursive),
+        watcher.watch(Path::new(SYSTEM_LAUNCH_AGENTS), RecursiveMode::Recursive),
+        watcher.watch(Path::new(ADMIN_LAUNCH_DAEMONS), RecursiveMode::Recursive),
+        watcher.watch(Path::new(GLOBAL_LAUNCH_DAEMONS), RecursiveMode::Recursive),
+    ];
+
+    for sub in watchers.iter() {
+        sub.expect("Must subscribe to fs events");
+    }
+
+    loop {
+        let event = rx.recv();
+        if event.is_err() {
+            continue;
+        }
+
+        let event = event.unwrap();
+
+        let reload_plists = match event {
+            DebouncedEvent::Create(pb) => fs::read_dir(pb),
+            DebouncedEvent::Write(pb) => fs::read_dir(pb),
+            DebouncedEvent::Remove(pb) => fs::read_dir(pb),
+            DebouncedEvent::Rename(_, new) => fs::read_dir(new),
+            _ => continue,
+        };
+
+        if reload_plists.is_err() {
+            continue;
+        }
+
+        insert_plists(readdir_filter_plists(reload_plists.unwrap()));
+    }
+}
+
+fn build_label_map_entry(plist_path: DirEntry) -> Option<(String, LaunchdEntryConfig)> {
+    let path = plist_path.path();
+    let path_string = path.to_string_lossy().to_string();
+
+    let label = plist::Value::from_file(path.clone()).ok()?;
+    let label = label
+        .as_dictionary()
+        .and_then(|d| d.get("Label"))
+        .and_then(|v| v.as_string());
+
+    let entry_type = if path_string.contains(ADMIN_LAUNCH_DAEMONS)
+        || path_string.contains(GLOBAL_LAUNCH_DAEMONS)
+    {
+        LaunchdEntryType::Daemon
+    } else {
+        LaunchdEntryType::Agent
+    };
+
+    let entry_location = if path_string.contains(USER_LAUNCH_AGENTS) {
+        LaunchdEntryLocation::User
+    } else if path_string.contains(GLOBAL_LAUNCH_AGENTS)
+        || path_string.contains(ADMIN_LAUNCH_DAEMONS)
+    {
+        LaunchdEntryLocation::Global
+    } else {
+        LaunchdEntryLocation::System
+    };
+
+    Some((label?.to_string(), LaunchdEntryConfig {
+        entry_location,
+        entry_type,
+        plist_path: path_string,
+        readonly: path
+            .metadata()
+            .map(|m| m.permissions().readonly())
+            .unwrap_or(true),
+    }))
+}
+
+fn readdir_filter_plists(rd: ReadDir) -> FilterMap<ReadDir, fn(futures::io::Result<DirEntry>) -> Option<DirEntry>> {
+    rd.filter_map(|e|  {
+        if e.is_err() {
+            return None;
+        }
+
+        let path = e.borrow().as_ref().unwrap().path();
+
+        if path.is_dir()
+            || path
+            .extension()
+            .map(|ex| ex.to_string_lossy().ne("plist"))
+            .unwrap_or(true) {
+            None
+        } else {
+            Some(e.unwrap())
+        }
+    })
+}
+
+fn insert_plists(plists: impl Iterator<Item=DirEntry>) {
+    let mut label_map = LABEL_TO_PLIST.lock().unwrap();
+
+    for plist_path in plists {
+        let entry = build_label_map_entry(plist_path);
+        if entry.is_none() { continue; }
+        let (label, entry) = entry.unwrap();
+        label_map.insert(label, entry);
+    }
+}
+
 /// Unsure if this is overkill, since the filenames
 /// usually match the label property. Still looking for
 /// a way to do dumpstate, dumpjpcategory without parsing the string
-fn init_label_map() {
+pub fn init_label_map(runtime_handle: &Handle) {
     let dirs = [
         USER_LAUNCH_AGENTS,
         GLOBAL_LAUNCH_AGENTS,
@@ -95,84 +213,16 @@ fn init_label_map() {
     let plists = dirs
         .iter()
         .filter_map(|&dirname| fs::read_dir(Path::new(dirname)).ok())
-        .flat_map(|rd| {
-            rd.flat_map(|e| {
-                if e.is_err() {
-                    return e.into_iter();
-                }
-                let path = e.borrow().as_ref().unwrap().path();
+        .flat_map(readdir_filter_plists);
 
-                if path.is_dir()
-                    || path
-                        .extension()
-                        .map(|ex| ex.to_string_lossy().ne("plist"))
-                        .unwrap_or(true)
-                {
-                    Err(()).into_iter()
-                } else {
-                    e.into_iter()
-                }
-            })
-        });
+    insert_plists(plists);
 
-    let mut label_map = LABEL_TO_PLIST.lock().unwrap();
-
-    for plist_path in plists {
-        let path = plist_path.path();
-        let path_string = path.to_string_lossy().to_string();
-
-        let label = plist::Value::from_file(path.clone());
-
-        if label.is_err() {
-            continue;
-        }
-
-        let label = label.unwrap();
-        let label = label
-            .as_dictionary()
-            .and_then(|d| d.get("Label"))
-            .and_then(|v| v.as_string());
-
-        if label.is_none() {
-            continue;
-        }
-
-        let entry_type = if path_string.contains(ADMIN_LAUNCH_DAEMONS)
-            || path_string.contains(GLOBAL_LAUNCH_DAEMONS)
-        {
-            LaunchdEntryType::Daemon
-        } else {
-            LaunchdEntryType::Agent
-        };
-
-        let entry_location = if path_string.contains(USER_LAUNCH_AGENTS) {
-            LaunchdEntryLocation::User
-        } else if path_string.contains(GLOBAL_LAUNCH_AGENTS)
-            || path_string.contains(ADMIN_LAUNCH_DAEMONS)
-        {
-            LaunchdEntryLocation::Global
-        } else {
-            LaunchdEntryLocation::System
-        };
-
-        label_map.insert(
-            label.unwrap().to_string(),
-            LaunchdEntryConfig {
-                entry_location,
-                entry_type,
-                plist_path: path_string,
-                readonly: path
-                    .metadata()
-                    .map(|m| m.permissions().readonly())
-                    .unwrap_or(true),
-            },
-        );
-    }
+    // Spawn fsnotify subscriber
+    runtime_handle.spawn(async { fsnotify_subscriber().await });
 }
 
 /// Get plist + fs meta for an entry by its label
 pub fn for_entry<S: Into<String>>(label: S) -> Option<LaunchdEntryConfig> {
-    LABEL_MAP_INIT.call_once(init_label_map);
     let label_map = LABEL_TO_PLIST.try_lock().ok()?;
     label_map.get(label.into().as_str()).map(|c| c.clone())
 }

--- a/launchk/src/main.rs
+++ b/launchk/src/main.rs
@@ -13,6 +13,7 @@ use crate::tui::root::RootLayout;
 use cursive::view::Resizable;
 use cursive::views::Panel;
 use cursive::Cursive;
+use crate::launchd::config::{init_label_map, LABEL_MAP_INIT};
 
 mod launchd;
 mod tui;
@@ -22,6 +23,9 @@ fn main() {
         .enable_all()
         .build()
         .unwrap();
+
+    // Cache launchd job plists, spawn fsnotify to keep up with changes
+    LABEL_MAP_INIT.call_once(|| { init_label_map(runtime.handle()) });
 
     let mut siv: Cursive = cursive::default();
     siv.load_toml(include_str!("tui/style.toml")).unwrap();


### PR DESCRIPTION
So damn close. This is the important feature! Let's leave `:edit` for last.

- [ ] Make the fs mapping the authoritative job list source, query for run status
- [ ] If a plist is added or removed, launchk should show changes in its list accordingly
- [ ] Omnibox `:load` (need XPC frame)
- [ ] Omnibox `:unload` (need XPC frame)
- [ ] Would be nice if the rows had an indicator of a service about to be added/removed (column for row? highlight row?)
- [ ] What do we do with errors? Modal? How do we get access to the siv instance? 

Misc: 

- What if a plist is invalid?