### PR TITLE
Better XPC release/retain usage, plist handling, omnibox usability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "launchk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitflags",
  "cursive",
@@ -1384,7 +1384,7 @@ checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 
 [[package]]
 name = "xpc-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bindgen",
  "bitflags",

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ While building launchk, XPC convenience glue was placed in `xpc-sys`.
 A big thanks to these open source projects and general resources:
 
 - [block](https://crates.io/crates/block) Obj-C block support, necessary for any XPC function taking `xpc_*_applier_t`  
-- [Cursive](https://github.com/gyscos/cursive) TUI  
-- [tokio](https://github.com/tokio-rs/tokio) ASIO  
-- [plist](https://crates.io/crates/plist) Parsing & validation for XML and binary plists  
-- [notify](https://docs.rs/notify/4.0.16/notify/) fsnotify  
+- [Cursive](https://github.com/gyscos/cursive)
+- [tokio](https://github.com/tokio-rs/tokio)
+- [plist](https://crates.io/crates/plist)
+- [notify](https://docs.rs/notify/4.0.16/notify/)
 - [bitflags](https://docs.rs/bitflags/1.2.1/bitflags/)  
 - [libc](https://crates.io/crates/libc)
 - [lazy_static](https://crates.io/crates/lazy_static)

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ A big thanks to these open source projects and general resources:
 - [geosnow - A Long Evening With macOS' sandbox](https://geosn0w.github.io/A-Long-Evening-With-macOS%27s-Sandbox/)  
 - [Bits of launchd - @5aelo](https://saelo.github.io/presentations/bits_of_launchd.pdf)  
 - [Audit tokens explained (e.g. ASID)](https://knight.sc/reverse%20engineering/2020/03/20/audit-tokens-explained.html)  
-- [objc.io XPC guide](https://www.objc.io/issues/14-mac/xpc/)  
+- [objc.io XPC guide](https://www.objc.io/issues/14-mac/xpc/)
+- [Fortinet XPC RE article](https://www.fortinet.com/blog/threat-research/a-look-into-xpc-internals--reverse-engineering-the-xpc-objects)
+- [This HN comment](https://news.ycombinator.com/item?id=2565780) re history
 - The various source links found in comments, from Chrome's sandbox and other headers with definitions for private API functions.
-- Last but not least, this is Apple's launchd after all, right :>)? I did not know systemd was inspired by launchd until I read [this HN comment](https://news.ycombinator.com/item?id=2565780), which sent me down this eventual rabbit hole :)  
+- After all, it is Apple's launchd :>)
 
 Everything else (C) David Stancu & Contributors 2021

--- a/launchk/Cargo.toml
+++ b/launchk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "launchk"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["David Stancu <dstancu@nyu.edu>"]
 edition = "2018"
 

--- a/launchk/src/launchd/plist.rs
+++ b/launchk/src/launchd/plist.rs
@@ -276,7 +276,9 @@ pub fn edit_and_replace(plist_meta: &LaunchdPlist) -> Result<(), String> {
         .duration_since(UNIX_EPOCH)
         .expect("Must get ts");
     let temp_path = Path::new(*TMP_DIR).join(format!("{}", now.as_secs()));
-    og_plist.to_file_xml(&temp_path).map_err(|e| e.to_string())?;
+    og_plist
+        .to_file_xml(&temp_path)
+        .map_err(|e| e.to_string())?;
 
     // Start $EDITOR
     let exit = Command::new(*EDITOR)
@@ -293,7 +295,7 @@ pub fn edit_and_replace(plist_meta: &LaunchdPlist) -> Result<(), String> {
         plist::Value::from_file(&temp_path).map_err(|e| format!("Changes not saved: {}", e))?;
 
     if og_plist == plist {
-        return Err("No changes made".to_string())
+        return Err("No changes made".to_string());
     }
 
     let writer = if is_binary {

--- a/launchk/src/launchd/plist.rs
+++ b/launchk/src/launchd/plist.rs
@@ -271,12 +271,12 @@ pub fn edit_and_replace(plist_meta: &LaunchdPlist) -> Result<(), String> {
         == PLIST_MAGIC;
 
     // plist -> validate with crate -> temp file
-    let plist = plist::Value::from_file(&plist_meta.plist_path).map_err(|e| e.to_string())?;
+    let og_plist = plist::Value::from_file(&plist_meta.plist_path).map_err(|e| e.to_string())?;
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Must get ts");
     let temp_path = Path::new(*TMP_DIR).join(format!("{}", now.as_secs()));
-    plist.to_file_xml(&temp_path).map_err(|e| e.to_string())?;
+    og_plist.to_file_xml(&temp_path).map_err(|e| e.to_string())?;
 
     // Start $EDITOR
     let exit = Command::new(*EDITOR)
@@ -291,6 +291,11 @@ pub fn edit_and_replace(plist_meta: &LaunchdPlist) -> Result<(), String> {
     // temp file -> validate with crate -> original
     let plist =
         plist::Value::from_file(&temp_path).map_err(|e| format!("Changes not saved: {}", e))?;
+
+    if og_plist == plist {
+        return Err("No changes made".to_string())
+    }
+
     let writer = if is_binary {
         plist::Value::to_file_binary
     } else {

--- a/launchk/src/launchd/query.rs
+++ b/launchk/src/launchd/query.rs
@@ -5,7 +5,6 @@ use crate::launchd::message::{
 use std::convert::TryFrom;
 use std::{collections::HashSet, os::unix::prelude::RawFd};
 
-use xpc_sys::xpc_retain;
 use xpc_sys::{
     objects::xpc_shmem::XPCShmem,
     traits::{xpc_pipeable::XPCPipeable, xpc_value::TryXPCValue},
@@ -142,13 +141,6 @@ pub fn dumpstate() -> Result<(usize, XPCShmem), XPCError> {
         0x1400000,
         i32::try_from(MAP_SHARED).expect("Must conv flags"),
     )?;
-
-    // segfault otherwise, the XPC dictionary gets dropped after
-    // pipe_routine_with_error_handling, so we need to make sure
-    // we retain shmem
-    unsafe {
-        xpc_retain(shmem.xpc_object.as_ptr());
-    }
 
     log::info!("Made shmem {:?}", shmem);
 

--- a/launchk/src/launchd/query.rs
+++ b/launchk/src/launchd/query.rs
@@ -146,7 +146,7 @@ pub fn dumpstate() -> Result<(usize, XPCShmem), XPCError> {
 
     let response = XPCDictionary::new()
         .extend(&DUMPSTATE)
-        .entry("shmem", shmem.xpc_object.clone())
+        .entry("shmem", &shmem.xpc_object)
         .pipe_routine_with_error_handling()?;
 
     let bytes_written: u64 = response.get(&["bytes-written"])?.xpc_value()?;

--- a/launchk/src/launchd/query.rs
+++ b/launchk/src/launchd/query.rs
@@ -142,8 +142,6 @@ pub fn dumpstate() -> Result<(usize, XPCShmem), XPCError> {
         i32::try_from(MAP_SHARED).expect("Must conv flags"),
     )?;
 
-    log::info!("Made shmem {:?}", shmem);
-
     let response = XPCDictionary::new()
         .extend(&DUMPSTATE)
         .entry("shmem", &shmem.xpc_object)

--- a/launchk/src/tui/omnibox/subscribed_view.rs
+++ b/launchk/src/tui/omnibox/subscribed_view.rs
@@ -59,7 +59,7 @@ pub trait OmniboxSubscriber: View {
 impl<T: OmniboxSubscriber> OmniboxSubscriber for ResizedView<T> {
     fn on_omnibox(&mut self, cmd: OmniboxEvent) -> OmniboxResult {
         self.with_view_mut(|v| v.on_omnibox(cmd))
-            .unwrap_or(Err(OmniboxError::StandardError))
+            .unwrap_or(Err(OmniboxError::ReferenceError))
     }
 }
 

--- a/launchk/src/tui/omnibox/view.rs
+++ b/launchk/src/tui/omnibox/view.rs
@@ -25,7 +25,7 @@ pub enum OmniboxEvent {
 
 #[derive(Debug, Clone)]
 pub enum OmniboxError {
-    StandardError,
+    ReferenceError,
     CommandError(String),
 }
 

--- a/launchk/src/tui/omnibox/view.rs
+++ b/launchk/src/tui/omnibox/view.rs
@@ -357,13 +357,16 @@ impl View for OmniboxView {
                     .send(OmniboxEvent::Command(OmniboxCommand::FocusServiceList))
                     .expect("Must focus");
                 Some(state.with_new(Some(OmniboxMode::Idle), None, Some("".to_string()), None))
-            },
+            }
             (Event::Char(':'), _) => {
                 Some(state.with_new(Some(OmniboxMode::CommandFilter), None, None, None))
             }
-            (Event::Char('/'), _) => {
-                Some(state.with_new(Some(OmniboxMode::LabelFilter), None, Some("".to_string()), None))
-            }
+            (Event::Char('/'), _) => Some(state.with_new(
+                Some(OmniboxMode::LabelFilter),
+                None,
+                Some("".to_string()),
+                None,
+            )),
             (e, OmniboxMode::Idle) => Self::handle_job_type_filter(&e, &*state),
             (e, _) => Self::handle_active(&e, &*state),
         };

--- a/launchk/src/tui/omnibox/view.rs
+++ b/launchk/src/tui/omnibox/view.rs
@@ -141,13 +141,6 @@ impl OmniboxView {
         };
 
         match (event, mode) {
-            // Toggle back to query from bitmask filters
-            (Event::Char(':'), OmniboxMode::JobTypeFilter) => {
-                Some(state.with_new(Some(OmniboxMode::CommandFilter), None, None, None))
-            }
-            (Event::Char('/'), OmniboxMode::JobTypeFilter) => {
-                Some(state.with_new(Some(OmniboxMode::LabelFilter), None, None, None))
-            }
             (ev, OmniboxMode::JobTypeFilter) => Self::handle_job_type_filter(ev, state),
             // User -> string filters
             (Event::Char(_), OmniboxMode::LabelFilter)
@@ -213,25 +206,6 @@ impl OmniboxView {
         };
 
         Some(state.with_new(Some(OmniboxMode::JobTypeFilter), None, None, Some(jtf)))
-    }
-
-    /// Leave idle state
-    fn handle_idle(event: &Event, state: &OmniboxState) -> Option<OmniboxState> {
-        match event {
-            Event::Char('/') => Some(state.with_new(
-                Some(OmniboxMode::LabelFilter),
-                Some("".to_string()),
-                None,
-                None,
-            )),
-            Event::Char(':') => Some(state.with_new(
-                Some(OmniboxMode::CommandFilter),
-                None,
-                Some("".to_string()),
-                None,
-            )),
-            _ => Self::handle_job_type_filter(event, state),
-        }
     }
 
     fn draw_command_header(&self, printer: &Printer<'_, '_>) {
@@ -383,8 +357,14 @@ impl View for OmniboxView {
                     .send(OmniboxEvent::Command(OmniboxCommand::FocusServiceList))
                     .expect("Must focus");
                 Some(state.with_new(Some(OmniboxMode::Idle), None, Some("".to_string()), None))
+            },
+            (Event::Char(':'), _) => {
+                Some(state.with_new(Some(OmniboxMode::CommandFilter), None, None, None))
             }
-            (e, OmniboxMode::Idle) => Self::handle_idle(&e, &*state),
+            (Event::Char('/'), _) => {
+                Some(state.with_new(Some(OmniboxMode::LabelFilter), None, Some("".to_string()), None))
+            }
+            (e, OmniboxMode::Idle) => Self::handle_job_type_filter(&e, &*state),
             (e, _) => Self::handle_active(&e, &*state),
         };
 
@@ -396,7 +376,7 @@ impl View for OmniboxView {
 
         self.tx
             .send(OmniboxEvent::StateUpdate(new_state.clone()))
-            .expect("Must broadcast state");
+            .expect("Must send state");
 
         drop(state);
         let mut write = self.state.write().expect("Must write state");

--- a/xpc-sys/Cargo.toml
+++ b/xpc-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xpc-sys"
 description = "Conveniently call routines with wrappers for xpc_pipe_routine() and go from Rust types to XPC objects and back!"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["David Stancu <dstancu@nyu.edu>"]
 license = "MIT"
 edition = "2018"

--- a/xpc-sys/README.md
+++ b/xpc-sys/README.md
@@ -233,8 +233,9 @@ A big thanks to these open source projects and general resources:
 - [geosnow - A Long Evening With macOS' sandbox](https://geosn0w.github.io/A-Long-Evening-With-macOS%27s-Sandbox/)  
 - [Bits of launchd - @5aelo](https://saelo.github.io/presentations/bits_of_launchd.pdf)  
 - [Audit tokens explained (e.g. ASID)](https://knight.sc/reverse%20engineering/2020/03/20/audit-tokens-explained.html)  
-- [objc.io XPC guide](https://www.objc.io/issues/14-mac/xpc/)  
+- [objc.io XPC guide](https://www.objc.io/issues/14-mac/xpc/)
+- [Fortinet XPC RE article](https://www.fortinet.com/blog/threat-research/a-look-into-xpc-internals--reverse-engineering-the-xpc-objects)
 - The various source links found in comments, from Chrome's sandbox and other headers with definitions for private API functions.
-- Last but not least, this is Apple's launchd after all, right :>)? I did not know systemd was inspired by launchd until I read [this HN comment](https://news.ycombinator.com/item?id=2565780), which sent me down this eventual rabbit hole :)
+- After all, it is Apple's launchd :>)
 
 Everything else (C) David Stancu & Contributors 2021

--- a/xpc-sys/README.md
+++ b/xpc-sys/README.md
@@ -219,10 +219,10 @@ bytes.read_to_string(buf);
 A big thanks to these open source projects and general resources:
 
 - [block](https://crates.io/crates/block) Obj-C block support, necessary for any XPC function taking `xpc_*_applier_t`  
-- [Cursive](https://github.com/gyscos/cursive) TUI  
-- [tokio](https://github.com/tokio-rs/tokio) ASIO  
-- [plist](https://crates.io/crates/plist) Parsing & validation for XML and binary plists  
-- [notify](https://docs.rs/notify/4.0.16/notify/) fsnotify  
+- [Cursive](https://github.com/gyscos/cursive)
+- [tokio](https://github.com/tokio-rs/tokio)
+- [plist](https://crates.io/crates/plist)
+- [notify](https://docs.rs/notify/4.0.16/notify/)
 - [bitflags](https://docs.rs/bitflags/1.2.1/bitflags/)  
 - [libc](https://crates.io/crates/libc)
 - [lazy_static](https://crates.io/crates/lazy_static)
@@ -235,6 +235,6 @@ A big thanks to these open source projects and general resources:
 - [Audit tokens explained (e.g. ASID)](https://knight.sc/reverse%20engineering/2020/03/20/audit-tokens-explained.html)  
 - [objc.io XPC guide](https://www.objc.io/issues/14-mac/xpc/)  
 - The various source links found in comments, from Chrome's sandbox and other headers with definitions for private API functions.
-- Last but not least, this is Apple's launchd after all, right :>)? I did not know systemd was inspired by launchd until I read [this HN comment](https://news.ycombinator.com/item?id=2565780), which sent me down this eventual rabbit hole :)  
+- Last but not least, this is Apple's launchd after all, right :>)? I did not know systemd was inspired by launchd until I read [this HN comment](https://news.ycombinator.com/item?id=2565780), which sent me down this eventual rabbit hole :)
 
 Everything else (C) David Stancu & Contributors 2021

--- a/xpc-sys/src/objects/unix_fifo.rs
+++ b/xpc-sys/src/objects/unix_fifo.rs
@@ -8,7 +8,7 @@ use std::{
     ptr::null_mut,
 };
 
-use crate::{rs_strerror, errno};
+use crate::{errno, rs_strerror};
 
 /// A wrapper around a UNIX FIFO
 pub struct UnixFifo(pub CString);

--- a/xpc-sys/src/objects/unix_fifo.rs
+++ b/xpc-sys/src/objects/unix_fifo.rs
@@ -8,9 +8,9 @@ use std::{
     ptr::null_mut,
 };
 
-use crate::rs_strerror;
+use crate::{rs_strerror, errno};
 
-/// A simple wrapper around a UNIX FIFO
+/// A wrapper around a UNIX FIFO
 pub struct UnixFifo(pub CString);
 
 impl UnixFifo {
@@ -26,28 +26,40 @@ impl UnixFifo {
         }
     }
 
-    /// Open the FIFO as O_RDONLY, read until EOF, clean up fd before returning the buffer.
-    pub fn block_and_read_bytes(&self) -> Vec<u8> {
+    /// Open O_RDONLY, read until EOF, close fd, return buffer.
+    pub fn block_and_read_bytes(&self) -> Result<Vec<u8>, String> {
         let Self(fifo_name) = self;
 
         let fifo_fd_read = unsafe { open(fifo_name.as_ptr(), O_RDONLY) };
+        log::info!("opened read fifo {}", fifo_fd_read);
         let mut file = unsafe { File::from_raw_fd(fifo_fd_read) };
 
         let mut buf: Vec<u8> = Vec::new();
         file.read_to_end(&mut buf).expect("Must read bytes");
 
-        unsafe { libc::close(fifo_fd_read) };
-
-        buf
+        Self::close(fifo_fd_read)?;
+        Ok(buf)
     }
 
-    /// Open O_WRONLY, pass to fn and clean up before returning.
-    pub fn with_writer<T>(&self, f: impl Fn(RawFd) -> T) -> T {
+    /// Open O_WRONLY, call fn, close fd, yield result
+    pub fn with_writer<T>(&self, f: impl Fn(RawFd) -> T) -> Result<T, String> {
         let Self(fifo_name) = self;
         let fifo_fd_write = unsafe { open(fifo_name.as_ptr(), O_WRONLY) };
-        let response = f(fifo_fd_write);
-        unsafe { libc::close(fifo_fd_write) };
-        response
+        log::info!("opened write fifo {}", fifo_fd_write);
+        let result = f(fifo_fd_write);
+        Self::close(fifo_fd_write)?;
+        Ok(result)
+    }
+
+    /// Wrap libc close()
+    pub fn close(fd: RawFd) -> Result<(), String> {
+        let err = unsafe { libc::close(fd) };
+
+        if err == 0 {
+            Ok(())
+        } else {
+            Err(rs_strerror(unsafe { errno }))
+        }
     }
 }
 
@@ -55,6 +67,6 @@ impl Drop for UnixFifo {
     fn drop(&mut self) {
         let Self(fifo_name) = self;
 
-        remove_file(&fifo_name.to_string_lossy().to_string()).expect("Must tear down FIFO");
+        remove_file(&fifo_name.to_string_lossy().to_string()).expect("Must rm FIFO");
     }
 }

--- a/xpc-sys/src/objects/xpc_dictionary.rs
+++ b/xpc-sys/src/objects/xpc_dictionary.rs
@@ -6,6 +6,7 @@ use std::os::raw::c_char;
 use std::ptr::{null, null_mut};
 use std::sync::Arc;
 
+use crate::objects;
 use crate::objects::xpc_error::XPCError;
 use crate::objects::xpc_error::XPCError::DictionaryError;
 use crate::objects::xpc_object::XPCObject;
@@ -13,7 +14,6 @@ use crate::rs_strerror;
 use crate::{
     errno, xpc_dictionary_apply, xpc_dictionary_create, xpc_dictionary_set_value, xpc_object_t,
 };
-use crate::{objects, xpc_retain};
 
 use block::ConcreteBlock;
 

--- a/xpc-sys/src/objects/xpc_dictionary.rs
+++ b/xpc-sys/src/objects/xpc_dictionary.rs
@@ -81,9 +81,7 @@ impl TryFrom<&XPCObject> for XPCDictionary {
 
     /// Copy data from XPC dictionary into a Rust HashMap
     fn try_from(object: &XPCObject) -> Result<XPCDictionary, XPCError> {
-        let XPCObject(_, object_type) = *object;
-
-        if object_type != *objects::xpc_type::Dictionary {
+        if object.xpc_type() != *objects::xpc_type::Dictionary {
             return Err(DictionaryError(
                 "Only XPC_TYPE_DICTIONARY allowed".to_string(),
             ));

--- a/xpc-sys/src/objects/xpc_dictionary.rs
+++ b/xpc-sys/src/objects/xpc_dictionary.rs
@@ -94,8 +94,6 @@ impl TryFrom<&XPCObject> for XPCDictionary {
 
         // https://developer.apple.com/documentation/xpc/1505404-xpc_dictionary_apply?language=objc
         let block = ConcreteBlock::new(move |key: *const c_char, value: xpc_object_t| {
-            // Prevent xpc_release() collection on block exit
-            unsafe { xpc_retain(value) };
             let str_key = unsafe { CStr::from_ptr(key).to_string_lossy().to_string() };
 
             let xpc_object: XPCObject = value.into();

--- a/xpc-sys/src/objects/xpc_dictionary.rs
+++ b/xpc-sys/src/objects/xpc_dictionary.rs
@@ -93,10 +93,9 @@ impl TryFrom<&XPCObject> for XPCDictionary {
 
         // https://developer.apple.com/documentation/xpc/1505404-xpc_dictionary_apply?language=objc
         let block = ConcreteBlock::new(move |key: *const c_char, value: xpc_object_t| {
-            unsafe { xpc_retain(value) };
+            let xpc_object: XPCObject = XPCObject::xpc_copy(value);
             let str_key = unsafe { CStr::from_ptr(key).to_string_lossy().to_string() };
 
-            let xpc_object: XPCObject = value.into();
             map_block_clone
                 .borrow_mut()
                 .insert(str_key, xpc_object.into());
@@ -170,7 +169,7 @@ where
                 let as_str: String = k.into();
                 let cstr = CString::new(as_str).unwrap();
                 log::trace!("Dictionary {:p} add {:?}: {:p}", dict, cstr, v.as_ptr());
-                xpc_dictionary_set_value(dict, cstr.as_ptr(), xpc_copy(v.as_ptr()));
+                xpc_dictionary_set_value(dict, cstr.as_ptr(), v.as_ptr());
             }
         }
 

--- a/xpc-sys/src/objects/xpc_dictionary.rs
+++ b/xpc-sys/src/objects/xpc_dictionary.rs
@@ -12,8 +12,8 @@ use crate::objects::xpc_error::XPCError::DictionaryError;
 use crate::objects::xpc_object::XPCObject;
 use crate::rs_strerror;
 use crate::{
-    errno, xpc_dictionary_apply, xpc_dictionary_create, xpc_dictionary_set_value, xpc_object_t, xpc_release,
-    xpc_copy, xpc_retain
+    errno, xpc_copy, xpc_dictionary_apply, xpc_dictionary_create, xpc_dictionary_set_value,
+    xpc_object_t, xpc_retain,
 };
 
 use block::ConcreteBlock;

--- a/xpc-sys/src/objects/xpc_error.rs
+++ b/xpc-sys/src/objects/xpc_error.rs
@@ -11,7 +11,6 @@ pub enum XPCError {
     ValueError(String),
     QueryError(String),
     IOError(String),
-    StandardError,
     NotFound,
 }
 

--- a/xpc-sys/src/objects/xpc_object.rs
+++ b/xpc-sys/src/objects/xpc_object.rs
@@ -1,13 +1,12 @@
 use crate::objects::xpc_type::XPCType;
 use crate::{
-    mach_port_t, xpc_array_append_value, xpc_array_create, xpc_bool_create, xpc_copy_description,
-    xpc_double_create, xpc_fd_create, xpc_int64_create, xpc_mach_recv_create, xpc_mach_send_create,
-    xpc_object_t, xpc_release, xpc_retain, xpc_string_create, xpc_uint64_create, xpc_copy
+    mach_port_t, xpc_array_append_value, xpc_array_create, xpc_bool_create, xpc_copy,
+    xpc_copy_description, xpc_double_create, xpc_fd_create, xpc_int64_create, xpc_mach_recv_create,
+    xpc_mach_send_create, xpc_object_t, xpc_release, xpc_string_create, xpc_uint64_create,
 };
 use std::ffi::{CStr, CString};
 use std::os::unix::prelude::RawFd;
 use std::ptr::null_mut;
-use std::sync::Arc;
 
 use crate::objects::xpc_dictionary::XPCDictionary;
 use std::fmt;

--- a/xpc-sys/src/objects/xpc_object.rs
+++ b/xpc-sys/src/objects/xpc_object.rs
@@ -2,7 +2,7 @@ use crate::objects::xpc_type::XPCType;
 use crate::{
     mach_port_t, xpc_array_append_value, xpc_array_create, xpc_bool_create, xpc_copy_description,
     xpc_double_create, xpc_fd_create, xpc_int64_create, xpc_mach_recv_create, xpc_mach_send_create,
-    xpc_object_t, xpc_release, xpc_string_create, xpc_uint64_create,
+    xpc_object_t, xpc_release, xpc_string_create, xpc_uint64_create, xpc_retain
 };
 use std::ffi::{CStr, CString};
 use std::os::unix::prelude::RawFd;
@@ -34,6 +34,8 @@ impl XPCObject {
     }
 
     fn new_raw(value: xpc_object_t) -> Self {
+        // XPC objects must live as long as the XPCObject struct
+        unsafe { xpc_retain(value) };
         Self(value, value.into())
     }
 }
@@ -62,7 +64,7 @@ impl fmt::Display for XPCObject {
 
 impl From<xpc_object_t> for XPCObject {
     fn from(value: xpc_object_t) -> Self {
-        XPCObject(value, value.into())
+        XPCObject::new_raw(value)
     }
 }
 

--- a/xpc-sys/src/objects/xpc_object.rs
+++ b/xpc-sys/src/objects/xpc_object.rs
@@ -14,7 +14,7 @@ use crate::objects::xpc_dictionary::XPCDictionary;
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct XPCObject(pub xpc_object_t, pub XPCType);
+pub struct XPCObject(xpc_object_t, pub XPCType);
 
 unsafe impl Send for XPCObject {}
 unsafe impl Sync for XPCObject {}
@@ -29,6 +29,7 @@ impl XPCObject {
         *xpc_type
     }
 
+    /// Get underlying xpc_object_t pointer
     pub fn as_ptr(&self) -> xpc_object_t {
         let XPCObject(object_ptr, _) = self;
         *object_ptr

--- a/xpc-sys/src/objects/xpc_object.rs
+++ b/xpc-sys/src/objects/xpc_object.rs
@@ -36,22 +36,18 @@ impl XPCObject {
 
     /// Read ref count (base + 0x0C). The count is incremented and
     /// decremented with calls to xpc_release and xpc_retain.
-    pub fn read_refs(&self) -> c_int {
+    pub unsafe fn read_refs(&self) -> c_int {
         let XPCObject(ptr, _) = self;
         let refs: *const c_int = *ptr as *const _;
-        unsafe {
-            *refs.offset(3)
-        }
+        *refs.offset(3)
     }
 
     /// Read xref count (base + 0x08). The count is incremented and
     /// decremented with calls to xpc_release and xpc_retain.
-    pub fn read_xrefs(&self) -> c_int {
+    pub unsafe fn read_xrefs(&self) -> c_int {
         let XPCObject(ptr, _) = self;
         let xrefs: *const c_int = *ptr as *const _;
-        unsafe {
-            *xrefs.offset(2)
-        }
+        *xrefs.offset(2)
     }
 }
 

--- a/xpc-sys/src/objects/xpc_object.rs
+++ b/xpc-sys/src/objects/xpc_object.rs
@@ -51,8 +51,8 @@ impl XPCObject {
 
     /// Should (?) return a deep copy of the underlying object
     /// https://developer.apple.com/documentation/xpc/1505584-xpc_copy
-    pub fn xpc_copy(&self) -> Self {
-        let clone = unsafe { xpc_copy(self.as_ptr()) };
+    pub fn xpc_copy(xpc_object: xpc_object_t) -> Self {
+        let clone = unsafe { xpc_copy(xpc_object) };
         Self::new(clone)
     }
 
@@ -202,7 +202,7 @@ impl<R: AsRef<XPCObject>> From<R> for XPCObject {
     /// Use xpc_copy() to copy out of refs.
     /// https://developer.apple.com/documentation/xpc/1505584-xpc_copy?language=objc
     fn from(other: R) -> Self {
-        other.as_ref().xpc_copy()
+        Self::xpc_copy(other.as_ref().as_ptr())
     }
 }
 

--- a/xpc-sys/src/objects/xpc_object.rs
+++ b/xpc-sys/src/objects/xpc_object.rs
@@ -2,7 +2,7 @@ use crate::objects::xpc_type::XPCType;
 use crate::{
     mach_port_t, xpc_array_append_value, xpc_array_create, xpc_bool_create, xpc_copy_description,
     xpc_double_create, xpc_fd_create, xpc_int64_create, xpc_mach_recv_create, xpc_mach_send_create,
-    xpc_object_t, xpc_release, xpc_string_create, xpc_uint64_create, xpc_retain
+    xpc_object_t, xpc_release, xpc_retain, xpc_string_create, xpc_uint64_create,
 };
 use std::ffi::{CStr, CString};
 use std::os::unix::prelude::RawFd;

--- a/xpc-sys/src/objects/xpc_shmem.rs
+++ b/xpc-sys/src/objects/xpc_shmem.rs
@@ -67,7 +67,7 @@ impl Drop for XPCShmem {
         log::info!(
             "XPCShmem drop (region: {:p}, object {:p})",
             region,
-            xpc_object.0
+            xpc_object.as_ptr()
         );
         unsafe { vm_deallocate(*task, *region as vm_address_t, *size) };
     }

--- a/xpc-sys/src/objects/xpc_shmem.rs
+++ b/xpc-sys/src/objects/xpc_shmem.rs
@@ -2,7 +2,7 @@ use crate::objects::xpc_error::XPCError;
 use crate::objects::xpc_object::XPCObject;
 use crate::{
     mach_port_t, mach_task_self_, rs_strerror, vm_address_t, vm_allocate, vm_deallocate, vm_size_t,
-    xpc_shmem_create,
+    xpc_shmem_create, xpc_retain
 };
 use std::ffi::c_void;
 use std::os::raw::c_int;

--- a/xpc-sys/src/objects/xpc_shmem.rs
+++ b/xpc-sys/src/objects/xpc_shmem.rs
@@ -2,7 +2,7 @@ use crate::objects::xpc_error::XPCError;
 use crate::objects::xpc_object::XPCObject;
 use crate::{
     mach_port_t, mach_task_self_, rs_strerror, vm_address_t, vm_allocate, vm_deallocate, vm_size_t,
-    xpc_shmem_create, xpc_retain
+    xpc_shmem_create,
 };
 use std::ffi::c_void;
 use std::os::raw::c_int;

--- a/xpc-sys/src/objects/xpc_shmem.rs
+++ b/xpc-sys/src/objects/xpc_shmem.rs
@@ -23,6 +23,7 @@ unsafe impl Send for XPCShmem {}
 
 impl XPCShmem {
     /// Allocate a region of memory of vm_size_t & flags, then wrap in a XPC Object
+    #[must_use]
     pub fn new(task: mach_port_t, size: vm_size_t, flags: c_int) -> Result<XPCShmem, XPCError> {
         let mut region: *mut c_void = null_mut();
         let err = unsafe {
@@ -57,6 +58,7 @@ impl XPCShmem {
 
     /// new() with _mach_task_self
     /// https://web.mit.edu/darwin/src/modules/xnu/osfmk/man/mach_task_self.html
+    #[must_use]
     pub fn new_task_self(size: vm_size_t, flags: c_int) -> Result<XPCShmem, XPCError> {
         unsafe { Self::new(mach_task_self_, size, flags) }
     }

--- a/xpc-sys/src/objects/xpc_type.rs
+++ b/xpc-sys/src/objects/xpc_type.rs
@@ -24,8 +24,7 @@ impl From<xpc_object_t> for XPCType {
 
 impl From<XPCObject> for XPCType {
     fn from(value: XPCObject) -> XPCType {
-        let XPCObject(_, xpc_type) = value;
-        xpc_type
+        value.xpc_type()
     }
 }
 
@@ -73,8 +72,7 @@ lazy_static! {
 
 /// Runtime type check for XPC object.
 pub fn check_xpc_type(object: &XPCObject, xpc_type: &XPCType) -> Result<(), XPCError> {
-    let XPCObject(_, obj_type) = object;
-    if *obj_type == *xpc_type {
+    if object.xpc_type() == *xpc_type {
         return Ok(());
     }
 

--- a/xpc-sys/src/traits/xpc_pipeable.rs
+++ b/xpc-sys/src/traits/xpc_pipeable.rs
@@ -4,7 +4,7 @@ use crate::objects::xpc_error::XPCError::PipeError;
 use crate::objects::xpc_object::XPCObject;
 use crate::{
     get_xpc_bootstrap_pipe, rs_xpc_strerror, xpc_object_t, xpc_pipe_routine,
-    xpc_pipe_routine_with_flags, xpc_retain
+    xpc_pipe_routine_with_flags, xpc_retain,
 };
 
 use crate::traits::xpc_value::TryXPCValue;

--- a/xpc-sys/src/traits/xpc_pipeable.rs
+++ b/xpc-sys/src/traits/xpc_pipeable.rs
@@ -4,7 +4,7 @@ use crate::objects::xpc_error::XPCError::PipeError;
 use crate::objects::xpc_object::XPCObject;
 use crate::{
     get_xpc_bootstrap_pipe, rs_xpc_strerror, xpc_object_t, xpc_pipe_routine,
-    xpc_pipe_routine_with_flags,
+    xpc_pipe_routine_with_flags, xpc_retain
 };
 
 use crate::traits::xpc_value::TryXPCValue;
@@ -65,20 +65,17 @@ pub trait XPCPipeable {
 
 impl XPCPipeable for XPCObject {
     fn pipe_routine(&self) -> XPCPipeResult {
-        let XPCObject(ptr, _) = self;
         let mut reply: xpc_object_t = null_mut();
-
-        let err = unsafe { xpc_pipe_routine(get_xpc_bootstrap_pipe(), *ptr, &mut reply) };
+        let err = unsafe { xpc_pipe_routine(get_xpc_bootstrap_pipe(), self.as_ptr(), &mut reply) };
 
         Self::handle_pipe_routine(reply, err)
     }
 
     fn pipe_routine_with_flags(&self, flags: u64) -> XPCPipeResult {
-        let XPCObject(ptr, _) = self;
         let mut reply: xpc_object_t = null_mut();
 
         let err = unsafe {
-            xpc_pipe_routine_with_flags(get_xpc_bootstrap_pipe(), *ptr, &mut reply, flags)
+            xpc_pipe_routine_with_flags(get_xpc_bootstrap_pipe(), self.as_ptr(), &mut reply, flags)
         };
 
         Self::handle_pipe_routine(reply, err)

--- a/xpc-sys/src/traits/xpc_pipeable.rs
+++ b/xpc-sys/src/traits/xpc_pipeable.rs
@@ -4,7 +4,7 @@ use crate::objects::xpc_error::XPCError::PipeError;
 use crate::objects::xpc_object::XPCObject;
 use crate::{
     get_xpc_bootstrap_pipe, rs_xpc_strerror, xpc_object_t, xpc_pipe_routine,
-    xpc_pipe_routine_with_flags, xpc_retain,
+    xpc_pipe_routine_with_flags,
 };
 
 use crate::traits::xpc_value::TryXPCValue;

--- a/xpc-sys/src/traits/xpc_value.rs
+++ b/xpc-sys/src/traits/xpc_value.rs
@@ -8,7 +8,7 @@ use crate::objects::xpc_type;
 use crate::{
     mach_port_t, size_t, xpc_array_apply, xpc_bool_get_value, xpc_double_get_value,
     xpc_int64_get_value, xpc_mach_send_get_right, xpc_object_t, xpc_retain,
-    xpc_string_get_string_ptr, xpc_type_get_name, xpc_uint64_get_value, xpc_copy, xpc_release
+    xpc_string_get_string_ptr, xpc_type_get_name, xpc_uint64_get_value,
 };
 
 use crate::objects::xpc_error::XPCError;
@@ -128,6 +128,7 @@ mod tests {
     use crate::objects::xpc_object::MachPortType;
     use crate::objects::xpc_object::XPCObject;
     use crate::traits::xpc_value::TryXPCValue;
+    use std::sync::Arc;
 
     #[test]
     fn xpc_to_rs_with_wrong_type() {
@@ -138,14 +139,6 @@ mod tests {
             as_u64.err().unwrap(),
             ValueError("Cannot get int64 as uint64".to_string())
         );
-    }
-
-    #[test]
-    fn xpc_value_vec() {
-        let xpc_array = XPCObject::from(vec![XPCObject::from("ohai")]);
-        let vec: Vec<XPCObject> = xpc_array.xpc_value().unwrap();
-        let ohai: String = vec.get(0).unwrap().xpc_value().unwrap();
-        assert_eq!(ohai, "ohai");
     }
 
     #[test]
@@ -201,7 +194,7 @@ mod tests {
     #[test]
     fn xpc_value_array() {
         let xpc_array = XPCObject::from(vec!["eins", "zwei", "polizei"]);
-        let rs_vec: Vec<XPCObject> = xpc_array.xpc_value().unwrap();
+        let rs_vec: Vec<Arc<XPCObject>> = xpc_array.xpc_value().unwrap();
 
         assert_eq!(
             rs_vec

--- a/xpc-sys/src/traits/xpc_value.rs
+++ b/xpc-sys/src/traits/xpc_value.rs
@@ -7,8 +7,8 @@ use crate::objects::xpc_object::{MachPortType, XPCObject};
 use crate::objects::xpc_type;
 use crate::{
     mach_port_t, size_t, xpc_array_apply, xpc_bool_get_value, xpc_double_get_value,
-    xpc_int64_get_value, xpc_mach_send_get_right, xpc_object_t, xpc_retain,
-    xpc_string_get_string_ptr, xpc_type_get_name, xpc_uint64_get_value,
+    xpc_int64_get_value, xpc_mach_send_get_right, xpc_object_t, xpc_string_get_string_ptr,
+    xpc_type_get_name, xpc_uint64_get_value,
 };
 
 use crate::objects::xpc_error::XPCError;
@@ -23,6 +23,7 @@ pub trait TryXPCValue<Out> {
 }
 
 impl TryXPCValue<i64> for XPCObject {
+    #[must_use]
     fn xpc_value(&self) -> Result<i64, XPCError> {
         check_xpc_type(&self, &xpc_type::Int64)?;
         Ok(unsafe { xpc_int64_get_value(self.as_ptr()) })
@@ -30,6 +31,7 @@ impl TryXPCValue<i64> for XPCObject {
 }
 
 impl TryXPCValue<u64> for XPCObject {
+    #[must_use]
     fn xpc_value(&self) -> Result<u64, XPCError> {
         check_xpc_type(&self, &xpc_type::UInt64)?;
         Ok(unsafe { xpc_uint64_get_value(self.as_ptr()) })
@@ -37,6 +39,7 @@ impl TryXPCValue<u64> for XPCObject {
 }
 
 impl TryXPCValue<f64> for XPCObject {
+    #[must_use]
     fn xpc_value(&self) -> Result<f64, XPCError> {
         check_xpc_type(&self, &xpc_type::Double)?;
         Ok(unsafe { xpc_double_get_value(self.as_ptr()) })
@@ -44,6 +47,7 @@ impl TryXPCValue<f64> for XPCObject {
 }
 
 impl TryXPCValue<String> for XPCObject {
+    #[must_use]
     fn xpc_value(&self) -> Result<String, XPCError> {
         check_xpc_type(&self, &xpc_type::String)?;
         let cstr = unsafe { CStr::from_ptr(xpc_string_get_string_ptr(self.as_ptr())) };
@@ -53,6 +57,7 @@ impl TryXPCValue<String> for XPCObject {
 }
 
 impl TryXPCValue<bool> for XPCObject {
+    #[must_use]
     fn xpc_value(&self) -> Result<bool, XPCError> {
         check_xpc_type(&self, &xpc_type::Bool)?;
         Ok(unsafe { xpc_bool_get_value(self.as_ptr()) })
@@ -60,6 +65,7 @@ impl TryXPCValue<bool> for XPCObject {
 }
 
 impl TryXPCValue<(MachPortType, mach_port_t)> for XPCObject {
+    #[must_use]
     fn xpc_value(&self) -> Result<(MachPortType, mach_port_t), XPCError> {
         let types = [
             check_xpc_type(&self, &xpc_type::MachSend).map(|()| MachPortType::Send),
@@ -82,6 +88,7 @@ impl TryXPCValue<(MachPortType, mach_port_t)> for XPCObject {
 }
 
 impl TryXPCValue<Vec<Arc<XPCObject>>> for XPCObject {
+    #[must_use]
     fn xpc_value(&self) -> Result<Vec<Arc<XPCObject>>, XPCError> {
         check_xpc_type(&self, &xpc_type::Array)?;
 

--- a/xpc-sys/src/traits/xpc_value.rs
+++ b/xpc-sys/src/traits/xpc_value.rs
@@ -89,9 +89,9 @@ impl TryXPCValue<Vec<Arc<XPCObject>>> for XPCObject {
         let vec_rc_clone = vec.clone();
 
         let block = ConcreteBlock::new(move |_: size_t, obj: xpc_object_t| {
-            unsafe { xpc_retain(obj) };
-            let xpc_object: XPCObject = obj.into();
+            let xpc_object: XPCObject = XPCObject::xpc_copy(obj);
             vec_rc_clone.borrow_mut().push(xpc_object.into());
+            true
         });
 
         let block = block.copy();


### PR DESCRIPTION
- Remove all `xpc_retain` calls from dictionary + query code
- Allow `:` and `/` switches during filtering
- Don't write plist if no changes (as it sits there is always validation before write, but don't do it unless we need to, esp since `plist::Value` implements `PartialEq`)
- `xpc_copy` from XPC -> Rust
- Fix memory leaks