### PR TITLE
Update to latest crates, add aarch to build targets, misc cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.7",
  "once_cell",
  "version_check",
 ]
@@ -98,8 +98,14 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.1",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -143,12 +149,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "clearscreen"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c969a6b6dadff9f3349b1f783f553e2411104763ca4789e1c6ca6a41f46a57b0"
+dependencies = [
+ "nix",
+ "terminfo",
+ "thiserror",
+ "which",
+ "winapi",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -158,7 +177,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -169,7 +188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3dc950f7cbc2aeb48ba253623fcd21357b15170a0e7c5f6433081d95808b7fd"
 dependencies = [
  "ahash",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-channel",
  "cursive_core",
  "lazy_static",
@@ -239,6 +258,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+dependencies = [
+ "cfg-if 0.1.10",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,7 +344,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "windows-sys",
@@ -416,13 +456,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -519,6 +570,7 @@ name = "launchk"
 version = "0.1.5"
 dependencies = [
  "bitflags",
+ "clearscreen",
  "cursive",
  "env_logger",
  "futures",
@@ -527,6 +579,7 @@ dependencies = [
  "notify",
  "notify-debouncer-mini",
  "plist",
+ "sudo",
  "tokio",
  "xpc-sys",
 ]
@@ -555,7 +608,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "winapi",
 ]
 
@@ -584,7 +637,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -613,7 +666,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -626,6 +679,27 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "nix"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "memchr",
+ "version_check",
 ]
 
 [[package]]
@@ -784,7 +858,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -796,6 +870,44 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -830,6 +942,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,12 +966,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+ "rand_pcg",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom 0.2.7",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -932,6 +1112,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1155,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "sudo"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bd84d4c082e18e37fef52c0088e4407dabcef19d23a607fb4b5ee03b7d5b83"
+dependencies = [
+ "libc",
+ "log",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,10 +1195,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminfo"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76971977e6121664ec1b960d1313aacfa75642adc93b9d4d53b247bd4cb1747e"
+dependencies = [
+ "dirs",
+ "fnv",
+ "nom 5.1.2",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "thiserror"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "time"
@@ -1090,6 +1319,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
+name = "git-version"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
+dependencies = [
+ "git-version-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.99",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +683,7 @@ dependencies = [
  "cursive",
  "env_logger 0.10.0",
  "futures",
+ "git-version",
  "lazy_static",
  "log",
  "notify 6.0.1",
@@ -1057,6 +1080,12 @@ dependencies = [
  "serde",
  "time",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,36 +4,23 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "const-random",
+ "getrandom",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "array-macro"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e97b4e522f9e55523001238ac59d13a8603af57f69980de5d8de4bbbe8ada6"
 
 [[package]]
 name = "atty"
@@ -43,14 +30,14 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -60,16 +47,15 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bindgen"
-version = "0.53.3"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if 0.1.10",
  "clang-sys",
  "clap",
- "env_logger 0.7.1",
+ "env_logger",
  "lazy_static",
  "lazycell",
  "log",
@@ -84,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block"
@@ -96,30 +82,24 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cexpr"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -128,23 +108,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "clang-sys"
-version = "0.29.3"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
+checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
 dependencies = [
  "glob",
  "libc",
@@ -153,79 +120,58 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "clap_lex",
+ "indexmap",
+ "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
-name = "const-random"
-version = "0.1.13"
+name = "clap_lex"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f590d95d011aa80b063ffe3253422ed5aa462af4e9867d43ce8337562bac77c4"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
- "const-random-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40"
-dependencies = [
- "getrandom",
- "lazy_static",
- "proc-macro-hack",
- "tiny-keccak",
+ "os_str_bytes",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
+ "cfg-if",
  "crossbeam-utils",
- "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "cursive"
-version = "0.15.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a308f690b21731878cc2a4e6a2d1e38d99399cabb0bb16a8ee978653b500f79b"
+checksum = "f3dc950f7cbc2aeb48ba253623fcd21357b15170a0e7c5f6433081d95808b7fd"
 dependencies = [
  "ahash",
- "cfg-if 0.1.10",
+ "cfg-if",
  "crossbeam-channel",
  "cursive_core",
- "enumset",
  "lazy_static",
  "libc",
  "log",
@@ -239,22 +185,19 @@ dependencies = [
 
 [[package]]
 name = "cursive_core"
-version = "0.1.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51898e2f69480355099e2dec58e5454fd6c126ef53d3cc425055b8184e083a4c"
+checksum = "4f8332f2d1dc815a1c72aa95cba6a557198b8e875371a8f1951037f510d7e257"
 dependencies = [
  "ahash",
- "chrono",
  "crossbeam-channel",
  "enum-map",
  "enumset",
  "lazy_static",
- "libc",
  "log",
  "num",
  "owning_ref",
- "signal-hook",
- "syn",
+ "time",
  "toml",
  "unicode-segmentation",
  "unicode-width",
@@ -263,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -273,23 +216,22 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.9.3",
  "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
@@ -297,20 +239,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-map"
-version = "0.6.4"
+name = "either"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4187999839f4ae8be35cf185d1381aa8dc32d2f5951349cc37ae49ebc4781855"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "enum-map"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a56d54c8dd9b3ad34752ed197a4eb2a6601bc010808eb097a04a58ae4c43e1"
 dependencies = [
- "array-macro",
  "enum-map-derive",
 ]
 
 [[package]]
 name = "enum-map-derive"
-version = "0.4.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c450cf304c9e18d45db562025a14fb1ca0f5c769b6f609309f81d4c31de455"
+checksum = "a9045e2676cd5af83c3b167d917b0a5c90a4d8e266e2683d6631b235c457fc27"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -319,19 +266,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.0.1"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "959a80a2062fedd66ed41d99736212de987b3a8c83a4c2cef243968075256bd1"
+checksum = "4799cdb24d48f1f8a7a98d06b7fde65a85a2d1e42b25a889f5406aa1fbefe074"
 dependencies = [
  "enumset_derive",
- "num-traits",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74bef436ac71820c5cf768d7af9ba33121246b09a00e09a55d94ef8095a875ac"
+checksum = "ea83a3fbdc1d999ccfbcbee717eab36f8edf2d71693a23ce0d7cca19e085304c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -341,25 +287,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
- "humantime 1.3.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
-dependencies = [
- "atty",
- "humantime 2.1.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -367,14 +300,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
- "winapi 0.3.9",
+ "windows-sys",
 ]
 
 [[package]]
@@ -384,45 +317,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fsevent"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
-dependencies = [
- "bitflags",
- "fsevent-sys",
-]
-
-[[package]]
 name = "fsevent-sys"
-version = "2.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -435,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -445,15 +352,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -462,17 +369,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -480,21 +386,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -505,18 +411,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -529,26 +433,17 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
 ]
 
 [[package]]
@@ -565,9 +460,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -575,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.7.1"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
  "bitflags",
  "inotify-sys",
@@ -594,44 +489,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.9"
+name = "itoa"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
+name = "kqueue"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+checksum = "4d6112e8f37b59803ac47a42d14f1f3a59bbf72fc6857ffc5be455e28a691f8e"
 dependencies = [
+ "kqueue-sys",
  "libc",
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
+name = "kqueue-sys"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
 dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
 name = "launchk"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bitflags",
  "cursive",
- "env_logger 0.8.3",
+ "env_logger",
  "futures",
  "lazy_static",
  "log",
  "notify",
+ "notify-debouncer-mini",
  "plist",
  "tokio",
  "xpc-sys",
@@ -651,18 +545,18 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cc",
- "winapi 0.3.9",
+ "cfg-if",
+ "winapi",
 ]
 
 [[package]]
@@ -676,20 +570,21 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -699,88 +594,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow 0.2.2",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.6",
- "ntapi",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-extras"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
-dependencies = [
- "lazycell",
- "log",
- "mio 0.6.23",
- "slab",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
-dependencies = [
- "socket2",
- "winapi 0.3.9",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ncurses"
-version = "5.100.0"
+version = "5.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db07ca287f6f4fb267e8b2ab0f9eb68f5a311a97315aaee845afa98f8a416b"
+checksum = "5e2c5d34d72657dc4b638a1c25d40aae81e4f1c699062f72f467237920752032"
 dependencies = [
  "cc",
  "libc",
@@ -788,58 +629,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "nom"
-version = "5.1.2"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
- "version_check",
+ "minimal-lexical",
 ]
 
 [[package]]
 name = "notify"
-version = "4.0.16"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2599080e87c9bd051ddb11b10074f4da7b1223298df65d4c2ec5bcf309af1533"
+checksum = "ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a"
 dependencies = [
  "bitflags",
+ "crossbeam-channel",
  "filetime",
- "fsevent",
  "fsevent-sys",
  "inotify",
+ "kqueue",
  "libc",
- "mio 0.6.23",
- "mio-extras",
+ "mio",
  "walkdir",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.3.6"
+name = "notify-debouncer-mini"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "e23e9fa24f094b143c1eb61f90ac6457de87be6987bc70746e0179f7dbc9007b"
 dependencies = [
- "winapi 0.3.9",
+ "notify",
 ]
 
 [[package]]
 name = "num"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
  "num-complex",
  "num-integer",
@@ -850,18 +680,18 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -869,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -880,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -891,28 +721,43 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.5.2"
+name = "num_threads"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "owning_ref"
@@ -925,27 +770,25 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
- "cfg-if 1.0.0",
- "instant",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "windows-sys",
 ]
 
 [[package]]
@@ -956,9 +799,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -968,86 +811,67 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plist"
-version = "1.1.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "679104537029ed2287c216bfb942bbf723f48ee98f0aef15611634173a74ef21"
+checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
 dependencies = [
  "base64",
- "chrono",
  "indexmap",
  "line-wrap",
  "serde",
+ "time",
  "xml-rs",
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rustc-hash"
@@ -1078,21 +902,21 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.1.17"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1100,34 +924,36 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
- "cfg-if 1.0.0",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1138,25 +964,19 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.57"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1166,80 +986,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301bdd13d23c49672926be451130892d274d3ba0b410c18e00daa7990ff38d99"
-dependencies = [
- "once_cell",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
+ "itoa",
  "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
+ "num_threads",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
  "memchr",
- "mio 0.7.9",
+ "mio",
  "num_cpus",
  "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.1.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1248,42 +1049,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.7.1"
+name = "unicode-ident"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
@@ -1292,30 +1087,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
 [[package]]
 name = "wasi"
-version = "0.10.1+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
+ "either",
  "libc",
+ "once_cell",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
@@ -1326,12 +1117,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1345,7 +1130,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1355,14 +1140,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
+name = "windows-sys"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
 ]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "xcrun"
@@ -1372,19 +1190,19 @@ checksum = "19faa325682887a17e8a740868bf298cf9f2df75b1f1ca941a818f91914794f0"
 
 [[package]]
 name = "xi-unicode"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71b85d8b1b8bfaf4b5c834187554d201a8cd621c2bbfa33efd41a3ecabd48b2"
+checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "xpc-sys"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bindgen",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
 name = "xpc-sys"
-version = "0.4.2"
+version = "0.4.1"
 dependencies = [
  "bindgen",
  "bitflags 2.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,39 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -28,7 +55,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -40,10 +67,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64"
-version = "0.13.0"
+name = "backtrace"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bindgen"
@@ -51,11 +93,11 @@ version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "clap",
- "env_logger",
+ "env_logger 0.9.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -73,6 +115,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block"
@@ -98,14 +146,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.1",
+ "nom",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -131,7 +173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "indexmap",
  "strsim",
@@ -150,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "clearscreen"
-version = "1.0.10"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c969a6b6dadff9f3349b1f783f553e2411104763ca4789e1c6ca6a41f46a57b0"
+checksum = "72f3f22f1a586604e62efd23f78218f3ccdecf7a33c4500db2d37d85a24fe994"
 dependencies = [
  "nix",
  "terminfo",
@@ -167,7 +209,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -177,18 +219,18 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
 [[package]]
 name = "cursive"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dc950f7cbc2aeb48ba253623fcd21357b15170a0e7c5f6433081d95808b7fd"
+checksum = "5438eb16bdd8af51b31e74764fef5d0a9260227a5ec82ba75c9d11ce46595839"
 dependencies = [
- "ahash",
- "cfg-if 1.0.0",
+ "ahash 0.8.3",
+ "cfg-if",
  "crossbeam-channel",
  "cursive_core",
  "lazy_static",
@@ -208,7 +250,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f8332f2d1dc815a1c72aa95cba6a557198b8e875371a8f1951037f510d7e257"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "crossbeam-channel",
  "enum-map",
  "enumset",
@@ -243,7 +285,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -254,16 +296,15 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
 name = "dirs"
-version = "2.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -301,7 +342,7 @@ checksum = "a9045e2676cd5af83c3b167d917b0a5c90a4d8e266e2683d6631b235c457fc27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -322,7 +363,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -339,15 +380,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -367,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -382,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -392,15 +467,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -409,38 +484,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -456,25 +531,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
@@ -496,6 +566,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "humantime"
@@ -525,7 +601,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "inotify-sys",
  "libc",
 ]
@@ -537,6 +613,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.2",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -561,7 +648,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -569,14 +656,14 @@ dependencies = [
 name = "launchk"
 version = "0.1.5"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "clearscreen",
  "cursive",
- "env_logger",
+ "env_logger 0.10.0",
  "futures",
  "lazy_static",
  "log",
- "notify",
+ "notify 6.0.1",
  "notify-debouncer-mini",
  "plist",
  "sudo",
@@ -598,9 +685,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -608,7 +695,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "winapi",
 ]
 
@@ -622,6 +709,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+
+[[package]]
 name = "lock_api"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,12 +726,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "maplit"
@@ -659,15 +749,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "mio"
-version = "0.8.4"
+name = "miniz_oxide"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -683,23 +782,14 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.2"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
+ "bitflags 1.3.2",
+ "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "memchr",
- "version_check",
+ "static_assertions",
 ]
 
 [[package]]
@@ -718,7 +808,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -731,12 +821,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5738a2795d57ea20abec2d6d76c6081186709c0024187cd5977265eda6598b51"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "mio",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "notify-debouncer-mini"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e23e9fa24f094b143c1eb61f90ac6457de87be6987bc70746e0179f7dbc9007b"
 dependencies = [
- "notify",
+ "notify 5.0.0",
 ]
 
 [[package]]
@@ -808,7 +916,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -819,6 +927,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -858,11 +975,11 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -873,18 +990,18 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "phf"
-version = "0.8.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.8.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -892,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.8.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
  "rand",
@@ -902,18 +1019,18 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.8.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pin-utils"
@@ -929,92 +1046,59 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plist"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
+checksum = "bdc0001cfea3db57a2e24bc0d818e9e20e554b5f97fabb9bc231dc240269ae06"
 dependencies = [
  "base64",
  "indexmap",
  "line-wrap",
+ "quick-xml",
  "serde",
  "time",
- "xml-rs",
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.21"
+name = "quick-xml"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "81b9228215d82c7b61490fec1de287136b5de6f5700f6e58ea9ad61a7964ca51"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
- "rand_pcg",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core",
-]
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "redox_syscall"
@@ -1022,7 +1106,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1031,7 +1115,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom",
  "redox_syscall",
  "thiserror",
 ]
@@ -1054,10 +1138,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "safemem"
@@ -1134,12 +1237,12 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1147,6 +1250,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1176,6 +1285,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "term_size"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,13 +1316,13 @@ dependencies = [
 
 [[package]]
 name = "terminfo"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76971977e6121664ec1b960d1313aacfa75642adc93b9d4d53b247bd4cb1747e"
+checksum = "666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f"
 dependencies = [
  "dirs",
  "fnv",
- "nom 5.1.2",
+ "nom",
  "phf",
  "phf_codegen",
 ]
@@ -1215,22 +1335,22 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1246,34 +1366,32 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.21.0"
+version = "1.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
+checksum = "40de3a2ba249dcb097e01be5e67a5ff53cf250397715a071a81543e8a832a920"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1319,12 +1437,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -1380,12 +1492,72 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1394,10 +1566,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1406,16 +1602,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "xcrun"
@@ -1430,17 +1674,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
-name = "xml-rs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
-
-[[package]]
 name = "xpc-sys"
 version = "0.4.1"
 dependencies = [
  "bindgen",
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "launchk"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.4.0",
  "clearscreen",
@@ -1675,10 +1675,10 @@ checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
 name = "xpc-sys"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bindgen",
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "block",
  "lazy_static",
  "libc",

--- a/launchk/Cargo.toml
+++ b/launchk/Cargo.toml
@@ -9,14 +9,14 @@ edition = "2018"
 [dependencies]
 xpc-sys = { path= "../xpc-sys" }
 lazy_static = "1.4.0"
-cursive = { version = "0.19.0", features = ["toml"] }
-tokio = { version = "1.21.0", features = ["full"] }
-futures = "0.3.24"
-plist = "1.3.1"
-bitflags = "1.3.2"
-notify = "5.0.0"
-log = "0.4.14"
-env_logger = "0.9.0"
+cursive = { version = "0.20.0", features = ["toml"] }
+tokio = { version = "1.31.0", features = ["full"] }
+futures = "0.3.28"
+plist = "1.5.0"
+bitflags = "2.4.0"
+notify = "6.0.1"
+log = "0.4.20"
+env_logger = "0.10.0"
 notify-debouncer-mini = { version = "*", default-features = false }
 sudo = "0.6.0"
-clearscreen = "1.0.10"
+clearscreen = "2.0.1"

--- a/launchk/Cargo.toml
+++ b/launchk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "launchk"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["David Stancu <dstancu@nyu.edu>"]
 edition = "2018"
 
@@ -9,11 +9,12 @@ edition = "2018"
 [dependencies]
 xpc-sys = { path= "../xpc-sys" }
 lazy_static = "1.4.0"
-cursive = { version = "0.15.0", features = ["toml"] }
-tokio = { version = "1", features = ["full"] }
-futures = "0.3"
-plist = "1.1.0"
-bitflags = "1.2.1"
-notify = "4.0.16"
+cursive = { version = "0.19.0", features = ["toml"] }
+tokio = { version = "1.21.0", features = ["full"] }
+futures = "0.3.24"
+plist = "1.3.1"
+bitflags = "1.3.2"
+notify = "5.0.0"
 log = "0.4.14"
-env_logger = "0.8.3"
+env_logger = "0.9.0"
+notify-debouncer-mini = { version = "*", default-features = false }

--- a/launchk/Cargo.toml
+++ b/launchk/Cargo.toml
@@ -18,3 +18,5 @@ notify = "5.0.0"
 log = "0.4.14"
 env_logger = "0.9.0"
 notify-debouncer-mini = { version = "*", default-features = false }
+sudo = "0.6.0"
+clearscreen = "1.0.10"

--- a/launchk/Cargo.toml
+++ b/launchk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "launchk"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["David Stancu <dstancu@nyu.edu>"]
 edition = "2018"
 

--- a/launchk/Cargo.toml
+++ b/launchk/Cargo.toml
@@ -20,3 +20,4 @@ env_logger = "0.10.0"
 notify-debouncer-mini = { version = "*", default-features = false }
 sudo = "0.6.0"
 clearscreen = "2.0.1"
+git-version = "0.3.5"

--- a/launchk/src/launchd/entry_status.rs
+++ b/launchk/src/launchd/entry_status.rs
@@ -16,7 +16,7 @@ lazy_static! {
         Mutex::new(HashMap::new());
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct LaunchdEntryStatus {
     pub plist: Option<LaunchdPlist>,
     pub limit_load_to_session_type: SessionType,

--- a/launchk/src/launchd/job_type_filter.rs
+++ b/launchk/src/launchd/job_type_filter.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::fmt::Formatter;
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Eq, PartialEq)]
+    #[derive(Clone, Copy, Default, Eq, PartialEq, Hash)]
     /// Bitmask for filtering on the job type, which is a mix
     /// of scope (where it's located), and kind (agent v. daemon)
     pub struct JobTypeFilter: u32 {

--- a/launchk/src/launchd/job_type_filter.rs
+++ b/launchk/src/launchd/job_type_filter.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::fmt::Formatter;
 
 bitflags! {
-    #[derive(Default)]
+    #[derive(Clone, Copy, Default, Eq, PartialEq)]
     /// Bitmask for filtering on the job type, which is a mix
     /// of scope (where it's located), and kind (agent v. daemon)
     pub struct JobTypeFilter: u32 {
@@ -54,5 +54,19 @@ impl fmt::Display for JobTypeFilter {
         }
 
         write!(f, "{}", display)
+    }
+}
+
+impl fmt::Debug for JobTypeFilter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            JobTypeFilter::SYSTEM => write!(f, "SYSTEM"),
+            JobTypeFilter::GLOBAL => write!(f, "GLOBAL"),
+            JobTypeFilter::USER => write!(f, "USER"),
+            JobTypeFilter::AGENT => write!(f, "AGENT"),
+            JobTypeFilter::DAEMON => write!(f, "DAEMON"),
+            JobTypeFilter::LOADED => write!(f, "LOADED"),
+            _ => write!(f, "")
+        }
     }
 }

--- a/launchk/src/launchd/job_type_filter.rs
+++ b/launchk/src/launchd/job_type_filter.rs
@@ -62,11 +62,11 @@ impl fmt::Debug for JobTypeFilter {
         match *self {
             JobTypeFilter::SYSTEM => write!(f, "SYSTEM"),
             JobTypeFilter::GLOBAL => write!(f, "GLOBAL"),
-            JobTypeFilter::USER   => write!(f, "USER"),
-            JobTypeFilter::AGENT  => write!(f, "AGENT"),
+            JobTypeFilter::USER => write!(f, "USER"),
+            JobTypeFilter::AGENT => write!(f, "AGENT"),
             JobTypeFilter::DAEMON => write!(f, "DAEMON"),
             JobTypeFilter::LOADED => write!(f, "LOADED"),
-            _                     => Ok(())
+            _ => Ok(()),
         }
     }
 }

--- a/launchk/src/launchd/job_type_filter.rs
+++ b/launchk/src/launchd/job_type_filter.rs
@@ -62,11 +62,11 @@ impl fmt::Debug for JobTypeFilter {
         match *self {
             JobTypeFilter::SYSTEM => write!(f, "SYSTEM"),
             JobTypeFilter::GLOBAL => write!(f, "GLOBAL"),
-            JobTypeFilter::USER => write!(f, "USER"),
-            JobTypeFilter::AGENT => write!(f, "AGENT"),
+            JobTypeFilter::USER   => write!(f, "USER"),
+            JobTypeFilter::AGENT  => write!(f, "AGENT"),
             JobTypeFilter::DAEMON => write!(f, "DAEMON"),
             JobTypeFilter::LOADED => write!(f, "LOADED"),
-            _ => write!(f, "")
+            _                     => Ok(())
         }
     }
 }

--- a/launchk/src/launchd/message.rs
+++ b/launchk/src/launchd/message.rs
@@ -1,5 +1,5 @@
-use xpc_sys::traits::query_builder::QueryBuilder;
 use xpc_sys::objects::xpc_dictionary::XPCDictionary;
+use xpc_sys::traits::query_builder::QueryBuilder;
 
 // A bunch of XPCDictionary 'protos' that can be extended to make XPC queries
 

--- a/launchk/src/launchd/plist.rs
+++ b/launchk/src/launchd/plist.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Once, RwLock};
 
 use crate::launchd::job_type_filter::JobTypeFilter;
-use notify_debouncer_mini::{new_debouncer, DebounceEventResult, notify::RecursiveMode};
+use notify_debouncer_mini::{new_debouncer, notify::RecursiveMode, DebounceEventResult};
 use std::fs::File;
 use std::io::Read;
 use std::process::Command;

--- a/launchk/src/launchd/plist.rs
+++ b/launchk/src/launchd/plist.rs
@@ -6,8 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Once, RwLock};
 
 use crate::launchd::job_type_filter::JobTypeFilter;
-use notify::RecursiveMode;
-use notify_debouncer_mini::{new_debouncer, DebounceEventResult};
+use notify_debouncer_mini::{new_debouncer, DebounceEventResult, notify::RecursiveMode};
 use std::fs::File;
 use std::io::Read;
 use std::process::Command;

--- a/launchk/src/launchd/plist.rs
+++ b/launchk/src/launchd/plist.rs
@@ -32,7 +32,7 @@ od -xc binary.plist
 */
 static PLIST_MAGIC: &str = "bplist00";
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum LaunchdEntryType {
     /// Runs on behalf of currently logged in user
     Agent,
@@ -46,7 +46,7 @@ impl fmt::Display for LaunchdEntryType {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum LaunchdEntryLocation {
     /// macOS system provided agent or daemon
     System,
@@ -64,7 +64,7 @@ impl fmt::Display for LaunchdEntryLocation {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct LaunchdPlist {
     pub entry_type: LaunchdEntryType,
     pub entry_location: LaunchdEntryLocation,

--- a/launchk/src/launchd/plist.rs
+++ b/launchk/src/launchd/plist.rs
@@ -1,4 +1,3 @@
-use std::borrow::{Borrow, BorrowMut};
 use std::collections::HashMap;
 use std::env;
 use std::fmt;
@@ -9,9 +8,8 @@ use std::sync::{Once, RwLock};
 use crate::launchd::job_type_filter::JobTypeFilter;
 use notify::RecursiveMode;
 use notify_debouncer_mini::{new_debouncer, DebounceEventResult};
-use std::fs::{DirEntry, File, ReadDir};
+use std::fs::File;
 use std::io::Read;
-use std::iter::FilterMap;
 use std::process::Command;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};

--- a/launchk/src/launchd/query.rs
+++ b/launchk/src/launchd/query.rs
@@ -2,8 +2,8 @@ use crate::launchd::message::{
     DISABLE_NAMES, DUMPJPCATEGORY, DUMPSTATE, ENABLE_NAMES, LIST_SERVICES, LOAD_PATHS, PROCINFO,
     UNLOAD_PATHS,
 };
+use std::collections::HashSet;
 use std::convert::TryFrom;
-use std::{collections::HashSet};
 
 use xpc_sys::{
     objects::xpc_shmem::XPCShmem,

--- a/launchk/src/launchd/query.rs
+++ b/launchk/src/launchd/query.rs
@@ -5,7 +5,12 @@ use crate::launchd::message::{
 use std::convert::TryFrom;
 use std::{collections::HashSet, os::unix::prelude::RawFd};
 
-use xpc_sys::{objects::xpc_shmem::XPCShmem, traits::{xpc_pipeable::XPCPipeable, xpc_value::TryXPCValue}, MAP_SHARED, rs_geteuid};
+use xpc_sys::{
+    objects::xpc_shmem::XPCShmem,
+    rs_geteuid,
+    traits::{xpc_pipeable::XPCPipeable, xpc_value::TryXPCValue},
+    MAP_SHARED,
+};
 
 use crate::launchd::entry_status::ENTRY_STATUS_CACHE;
 use std::iter::FromIterator;
@@ -54,24 +59,25 @@ pub fn list_all() -> HashSet<String> {
         everything.push(DomainType::User);
     }
 
-    let list = everything.iter()
-    .filter_map(|t| {
-        let svc_for_type = list(t.clone(), None)
-            .and_then(|d| d.get_as_dictionary(&["services"]))
-            .map(|XPCDictionary(ref hm)| hm.keys().map(|k| k.clone()).collect());
+    let list = everything
+        .iter()
+        .filter_map(|t| {
+            let svc_for_type = list(t.clone(), None)
+                .and_then(|d| d.get_as_dictionary(&["services"]))
+                .map(|XPCDictionary(ref hm)| hm.keys().map(|k| k.clone()).collect());
 
-        if svc_for_type.is_err() {
-            log::error!(
-                "[query/list_all]: poll error {}, domain, {}",
-                svc_for_type.err().unwrap(),
-                t
-            );
-            None
-        } else {
-            svc_for_type.ok()
-        }
-    })
-    .flat_map(|k: Vec<String>| k.into_iter());
+            if svc_for_type.is_err() {
+                log::error!(
+                    "[query/list_all]: poll error {}, domain, {}",
+                    svc_for_type.err().unwrap(),
+                    t
+                );
+                None
+            } else {
+                svc_for_type.ok()
+            }
+        })
+        .flat_map(|k: Vec<String>| k.into_iter());
 
     HashSet::from_iter(list)
 }

--- a/launchk/src/launchd/query.rs
+++ b/launchk/src/launchd/query.rs
@@ -5,11 +5,7 @@ use crate::launchd::message::{
 use std::convert::TryFrom;
 use std::{collections::HashSet, os::unix::prelude::RawFd};
 
-use xpc_sys::{
-    objects::xpc_shmem::XPCShmem,
-    traits::{xpc_pipeable::XPCPipeable, xpc_value::TryXPCValue},
-    MAP_SHARED,
-};
+use xpc_sys::{objects::xpc_shmem::XPCShmem, traits::{xpc_pipeable::XPCPipeable, xpc_value::TryXPCValue}, MAP_SHARED, rs_geteuid};
 
 use crate::launchd::entry_status::ENTRY_STATUS_CACHE;
 use std::iter::FromIterator;
@@ -48,17 +44,36 @@ pub fn list(domain_type: DomainType, name: Option<String>) -> Result<XPCDictiona
 
 /// Query for jobs across all domain types
 pub fn list_all() -> HashSet<String> {
-    let everything = (DomainType::System as u64..DomainType::RequestorDomain as u64)
-        .filter_map(|t| {
-            let svc_for_type = list(t.into(), None)
-                .and_then(|d| d.get_as_dictionary(&["services"]))
-                .map(|XPCDictionary(ref hm)| hm.keys().map(|k| k.clone()).collect());
+    let mut everything = vec![
+        DomainType::System,
+        DomainType::RequestorUserDomain,
+        DomainType::RequestorDomain,
+    ];
 
+    if rs_geteuid() == 0 {
+        everything.push(DomainType::User);
+    }
+
+    let list = everything.iter()
+    .filter_map(|t| {
+        let svc_for_type = list(t.clone(), None)
+            .and_then(|d| d.get_as_dictionary(&["services"]))
+            .map(|XPCDictionary(ref hm)| hm.keys().map(|k| k.clone()).collect());
+
+        if svc_for_type.is_err() {
+            log::error!(
+                "[query/list_all]: poll error {}, domain, {}",
+                svc_for_type.err().unwrap(),
+                t
+            );
+            None
+        } else {
             svc_for_type.ok()
-        })
-        .flat_map(|k: Vec<String>| k.into_iter());
+        }
+    })
+    .flat_map(|k: Vec<String>| k.into_iter());
 
-    HashSet::from_iter(everything)
+    HashSet::from_iter(list)
 }
 
 pub fn load<S: Into<String>>(

--- a/launchk/src/main.rs
+++ b/launchk/src/main.rs
@@ -11,6 +11,7 @@ extern crate plist;
 
 use cursive::view::Resizable;
 use cursive::views::{NamedView, Panel};
+use git_version::git_version;
 use std::process::exit;
 
 use crate::launchd::plist::{init_plist_map, PLIST_MAP_INIT};
@@ -38,7 +39,7 @@ fn main() {
     let root_layout = NamedView::new("root_layout", root_layout);
 
     let panel = Panel::new(root_layout)
-        .title("launchk")
+        .title(format!("launchk ({})", git_version!()))
         .full_width()
         .full_height();
 

--- a/launchk/src/main.rs
+++ b/launchk/src/main.rs
@@ -9,6 +9,7 @@ extern crate bitflags;
 
 extern crate plist;
 
+use clearscreen;
 use cursive::view::Resizable;
 use cursive::views::{NamedView, Panel};
 use git_version::git_version;
@@ -50,5 +51,6 @@ fn main() {
     // Fix reset on exit
     // https://github.com/gyscos/cursive/issues/415
     drop(siv);
+    clearscreen::clear().expect("Clear");
     exit(0);
 }

--- a/launchk/src/main.rs
+++ b/launchk/src/main.rs
@@ -11,7 +11,6 @@ extern crate plist;
 
 use cursive::view::Resizable;
 use cursive::views::{NamedView, Panel};
-use cursive::Cursive;
 use std::process::exit;
 
 use crate::launchd::plist::{init_plist_map, PLIST_MAP_INIT};
@@ -31,7 +30,7 @@ fn main() {
     // Cache launchd job plist paths, spawn fsnotify to keep up with changes
     PLIST_MAP_INIT.call_once(|| init_plist_map(runtime.handle()));
 
-    let mut siv: Cursive = cursive::default();
+    let mut siv = cursive::default();
     siv.load_toml(include_str!("tui/style.toml"))
         .expect("Must load styles");
 

--- a/launchk/src/tui/dialog.rs
+++ b/launchk/src/tui/dialog.rs
@@ -8,10 +8,10 @@ use cursive::{
 };
 
 use crate::launchd::entry_status::{get_entry_status, LaunchdEntryStatus};
+use crate::tui::omnibox::command::OmniboxCommand;
 use crate::tui::omnibox::command::OMNIBOX_COMMANDS;
 use crate::tui::omnibox::view::OmniboxEvent;
 use crate::tui::root::CbSinkMessage;
-use crate::tui::omnibox::command::OmniboxCommand;
 use xpc_sys::csr::{csr_check, CsrConfig};
 use xpc_sys::enums::{DomainType, SessionType};
 

--- a/launchk/src/tui/dialog.rs
+++ b/launchk/src/tui/dialog.rs
@@ -75,7 +75,7 @@ pub fn domain_session_prompt<S: Into<String>>(
 
         // Build domain type list
         let mut domain_type_layout = LinearLayout::vertical()
-            .child(TextView::new("Domain Type").effect(Effect::Bold))
+            .child(TextView::new("Domain Type").style(Effect::Bold))
             .child(DummyView);
 
         for d in DomainType::System as u64..DomainType::Unknown as u64 {
@@ -93,7 +93,7 @@ pub fn domain_session_prompt<S: Into<String>>(
 
         if !domain_only {
             session_type_layout = session_type_layout
-                .child(TextView::new("Session Type").effect(Effect::Bold))
+                .child(TextView::new("Session Type").style(Effect::Bold))
                 .child(DummyView);
 
             for s in SessionType::Aqua as u64..SessionType::Unknown as u64 {

--- a/launchk/src/tui/dialog.rs
+++ b/launchk/src/tui/dialog.rs
@@ -160,7 +160,13 @@ pub fn show_csr_info() -> CbSinkMessage {
 pub fn show_help() -> CbSinkMessage {
     let commands = OMNIBOX_COMMANDS
         .iter()
-        .map(|(cmd, desc, _)| format!("{:<15}: {}", cmd, desc.chars().filter(|c| c.is_ascii()).collect::<String>()))
+        .map(|(cmd, desc, _)| {
+            format!(
+                "{:<15}: {}",
+                cmd,
+                desc.chars().filter(|c| c.is_ascii()).collect::<String>()
+            )
+        })
         .collect::<Vec<String>>();
 
     Box::new(move |siv| {

--- a/launchk/src/tui/dialog.rs
+++ b/launchk/src/tui/dialog.rs
@@ -42,7 +42,7 @@ pub fn show_prompt(
                 commands
                     .iter()
                     .try_for_each(|c| tx.send(OmniboxEvent::Command(c.clone())))
-                    .expect("Must sent commands");
+                    .expect("Must send commands");
 
                 s.pop_layer();
             })

--- a/launchk/src/tui/dialog.rs
+++ b/launchk/src/tui/dialog.rs
@@ -160,7 +160,7 @@ pub fn show_csr_info() -> CbSinkMessage {
 pub fn show_help() -> CbSinkMessage {
     let commands = OMNIBOX_COMMANDS
         .iter()
-        .map(|(cmd, desc, _)| format!("{}: {}", cmd, desc))
+        .map(|(cmd, desc, _)| format!("{:<15}: {}", cmd, desc.chars().filter(|c| c.is_ascii()).collect::<String>()))
         .collect::<Vec<String>>();
 
     Box::new(move |siv| {

--- a/launchk/src/tui/omnibox/command.rs
+++ b/launchk/src/tui/omnibox/command.rs
@@ -63,7 +63,7 @@ pub static OMNIBOX_COMMANDS: [(&str, &str, OmniboxCommand); 12] = [
     ),
     (
         "edit",
-        "✍️  Edit plist with $EDITOR, then reload job",
+        "✍️  Edit plist with $EDITOR then reload job",
         OmniboxCommand::Edit,
     ),
     (

--- a/launchk/src/tui/omnibox/command.rs
+++ b/launchk/src/tui/omnibox/command.rs
@@ -1,5 +1,5 @@
-use xpc_sys::enums::{DomainType, SessionType};
 use std::fmt;
+use xpc_sys::enums::{DomainType, SessionType};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum OmniboxCommand {

--- a/launchk/src/tui/omnibox/command.rs
+++ b/launchk/src/tui/omnibox/command.rs
@@ -4,6 +4,8 @@ use xpc_sys::enums::{DomainType, SessionType};
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum OmniboxCommand {
     Chain(Vec<OmniboxCommand>),
+    // (message, on ok)
+    Confirm(String, Vec<OmniboxCommand>),
     // Try to see if we have session type & domain in entry_status,
     // to avoid having to prompt the user
     LoadRequest,
@@ -17,8 +19,6 @@ pub enum OmniboxCommand {
     Enable(DomainType),
     Disable(DomainType),
     Edit,
-    // (message, on ok)
-    Confirm(String, Vec<OmniboxCommand>),
     // (unit label, prompt for domain only?, action gen fn)
     DomainSessionPrompt(
         String,
@@ -30,6 +30,7 @@ pub enum OmniboxCommand {
     DumpState,
     DumpJetsamPropertiesCategory,
     ProcInfo,
+    Sudo,
     Help,
     Quit,
 }

--- a/launchk/src/tui/omnibox/command.rs
+++ b/launchk/src/tui/omnibox/command.rs
@@ -89,5 +89,5 @@ pub static OMNIBOX_COMMANDS: [(&str, &str, OmniboxCommand); 12] = [
         OmniboxCommand::ProcInfo,
     ),
     ("help", "🤔  Show all commands", OmniboxCommand::Help),
-    ("exit", "🚪 see ya!", OmniboxCommand::Quit),
+    ("exit", "🚪  see ya!", OmniboxCommand::Quit),
 ];

--- a/launchk/src/tui/omnibox/view.rs
+++ b/launchk/src/tui/omnibox/view.rs
@@ -28,6 +28,7 @@ pub enum OmniboxEvent {
 pub enum OmniboxError {
     ReferenceError,
     CommandError(String),
+    Many(Vec<OmniboxError>),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/launchk/src/tui/omnibox/view.rs
+++ b/launchk/src/tui/omnibox/view.rs
@@ -10,6 +10,7 @@ use cursive::direction::Direction;
 use cursive::event::{Event, EventResult, Key};
 use cursive::theme::{BaseColor, Color, Effect, Style};
 use cursive::{Printer, Vec2, View, XY};
+use cursive::view::CannotFocus;
 
 use crate::launchd::job_type_filter::JobTypeFilter;
 use crate::tui::omnibox::command::OmniboxCommand;
@@ -388,7 +389,7 @@ impl View for OmniboxView {
         EventResult::Consumed(None)
     }
 
-    fn take_focus(&mut self, _: Direction) -> bool {
-        true
+    fn take_focus(&mut self, _: Direction) -> Result<EventResult, CannotFocus> {
+        Ok(EventResult::Consumed(None))
     }
 }

--- a/launchk/src/tui/omnibox/view.rs
+++ b/launchk/src/tui/omnibox/view.rs
@@ -9,8 +9,8 @@ use tokio::time::interval;
 use cursive::direction::Direction;
 use cursive::event::{Event, EventResult, Key};
 use cursive::theme::{BaseColor, Color, Effect, Style};
-use cursive::{Printer, Vec2, View, XY};
 use cursive::view::CannotFocus;
+use cursive::{Printer, Vec2, View, XY};
 
 use crate::launchd::job_type_filter::JobTypeFilter;
 use crate::tui::omnibox::command::OmniboxCommand;

--- a/launchk/src/tui/pager.rs
+++ b/launchk/src/tui/pager.rs
@@ -5,6 +5,7 @@ use std::sync::mpsc::Sender;
 
 use super::root::CbSinkMessage;
 use cursive::Cursive;
+use clearscreen;
 
 lazy_static! {
     static ref PAGER: String = env::var("PAGER").unwrap_or("less".to_string());
@@ -12,9 +13,7 @@ lazy_static! {
 
 /// Show $PAGER (or less), write buf, and clear Cursive after exiting
 pub fn show_pager(cbsink: &Sender<CbSinkMessage>, buf: &[u8]) -> Result<(), String> {
-    cbsink
-        .send(Box::new(Cursive::clear))
-        .expect("Must clear before");
+    clearscreen::clear().expect("Must clear screen");
 
     let mut pager = Command::new(&*PAGER)
         .stdin(Stdio::piped())

--- a/launchk/src/tui/pager.rs
+++ b/launchk/src/tui/pager.rs
@@ -4,8 +4,8 @@ use std::process::{Command, Stdio};
 use std::sync::mpsc::Sender;
 
 use super::root::CbSinkMessage;
-use cursive::Cursive;
 use clearscreen;
+use cursive::Cursive;
 
 lazy_static! {
     static ref PAGER: String = env::var("PAGER").unwrap_or("less".to_string());

--- a/launchk/src/tui/root.rs
+++ b/launchk/src/tui/root.rs
@@ -110,12 +110,10 @@ impl RootLayout {
         let (tx, rx): (Sender<CbSinkMessage>, Receiver<CbSinkMessage>) = channel();
         let sink = siv.cb_sink().clone();
 
-        thread::spawn(move || {
-            loop {
-                if let Ok(cb_sink_msg) = rx.recv() {
-                    sink.send(cb_sink_msg)
-                        .expect("Cannot forward CbSink message")
-                }
+        thread::spawn(move || loop {
+            if let Ok(cb_sink_msg) = rx.recv() {
+                sink.send(cb_sink_msg)
+                    .expect("Cannot forward CbSink message")
             }
         });
 
@@ -255,8 +253,10 @@ impl OmniboxSubscriber for RootLayout {
                 Ok(None)
             }
             OmniboxEvent::Command(OmniboxCommand::Sudo) => {
-                clearscreen::clear().map_err(|_| OmniboxError::CommandError("Cannot clear".to_string()))?;
-                sudo::escalate_if_needed().map_err(|_| OmniboxError::CommandError("Cannot sudo".to_string()))?;
+                clearscreen::clear()
+                    .map_err(|_| OmniboxError::CommandError("Cannot clear".to_string()))?;
+                sudo::escalate_if_needed()
+                    .map_err(|_| OmniboxError::CommandError("Cannot sudo".to_string()))?;
                 Ok(None)
             }
             // Triggered when toggling to idle

--- a/launchk/src/tui/root.rs
+++ b/launchk/src/tui/root.rs
@@ -21,7 +21,6 @@ use crate::tui::omnibox::subscribed_view::{
 use crate::tui::omnibox::view::{OmniboxError, OmniboxEvent, OmniboxView};
 use crate::tui::pager::show_pager;
 use crate::tui::service_list::view::ServiceListView;
-use crate::tui::sysinfo::SysInfo;
 use crate::{
     launchd::query::dumpjpcategory,
     tui::dialog::{show_csr_info, show_help},
@@ -82,7 +81,7 @@ impl RootLayout {
     }
 
     fn setup(&mut self, omnibox: OmniboxView) {
-        let sysinfo = Panel::new(SysInfo::default().layout).full_width();
+        let sysinfo = Panel::new(crate::tui::sysinfo::make_layout());
 
         let omnibox = Panel::new(NamedView::new("omnibox", omnibox))
             .full_width()

--- a/launchk/src/tui/root.rs
+++ b/launchk/src/tui/root.rs
@@ -235,7 +235,8 @@ impl OmniboxSubscriber for RootLayout {
     fn on_omnibox(&mut self, cmd: OmniboxEvent) -> OmniboxResult {
         match cmd {
             OmniboxEvent::Command(OmniboxCommand::Chain(cmds)) => {
-               let errors: Vec<OmniboxError> = cmds.iter()
+                let errors: Vec<OmniboxError> = cmds
+                    .iter()
                     .filter_map(|c| self.on_omnibox(OmniboxEvent::Command(c.clone())).err())
                     .collect();
 

--- a/launchk/src/tui/root.rs
+++ b/launchk/src/tui/root.rs
@@ -82,7 +82,7 @@ impl RootLayout {
     }
 
     fn setup(&mut self, omnibox: OmniboxView) {
-        let sysinfo = Panel::new(SysInfo::default()).full_width();
+        let sysinfo = Panel::new(SysInfo::default().layout).full_width();
 
         let omnibox = Panel::new(NamedView::new("omnibox", omnibox))
             .full_width()
@@ -252,6 +252,11 @@ impl OmniboxSubscriber for RootLayout {
                         s.quit();
                     }))
                     .expect("Must quit");
+                Ok(None)
+            }
+            OmniboxEvent::Command(OmniboxCommand::Sudo) => {
+                clearscreen::clear().map_err(|_| OmniboxError::CommandError("Cannot clear".to_string()))?;
+                sudo::escalate_if_needed().map_err(|_| OmniboxError::CommandError("Cannot sudo".to_string()))?;
                 Ok(None)
             }
             // Triggered when toggling to idle

--- a/launchk/src/tui/root.rs
+++ b/launchk/src/tui/root.rs
@@ -102,7 +102,7 @@ impl RootLayout {
 
         self.layout
             .set_focus_index(RootLayoutChildren::ServiceList as usize)
-            .unwrap_or(());
+            .unwrap();
     }
 
     /// Cursive uses a different crate for its channels (?), so this is some glue

--- a/launchk/src/tui/root.rs
+++ b/launchk/src/tui/root.rs
@@ -3,7 +3,6 @@ use std::collections::VecDeque;
 use std::ptr::slice_from_raw_parts;
 use std::sync::mpsc::{channel, Receiver, Sender};
 
-
 use cursive::event::{Event, EventResult, Key};
 use cursive::traits::{Resizable, Scrollable};
 use cursive::view::ViewWrapper;
@@ -11,8 +10,6 @@ use cursive::views::{LinearLayout, NamedView, Panel};
 use cursive::{Cursive, Vec2, View};
 
 use tokio::runtime::Handle;
-
-
 
 use crate::tui::omnibox::command::OmniboxCommand;
 use crate::tui::omnibox::subscribed_view::{

--- a/launchk/src/tui/service_list/list_item.rs
+++ b/launchk/src/tui/service_list/list_item.rs
@@ -4,7 +4,7 @@ use crate::launchd::entry_status::LaunchdEntryStatus;
 use crate::launchd::job_type_filter::JobTypeFilter;
 use crate::tui::table::table_list_view::TableListItem;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ServiceListItem {
     pub name: String,
     pub status: LaunchdEntryStatus,

--- a/launchk/src/tui/service_list/view.rs
+++ b/launchk/src/tui/service_list/view.rs
@@ -209,7 +209,7 @@ impl ServiceListView {
                     )),
                     (st, dt) => Ok(Some(OmniboxCommand::Chain(vec![
                         OmniboxCommand::Unload(dt.clone(), None),
-                        OmniboxCommand::Load(st, dt, None),
+                        OmniboxCommand::Load(st.clone(), dt.clone(), None),
                     ]))),
                 }
             }

--- a/launchk/src/tui/service_list/view.rs
+++ b/launchk/src/tui/service_list/view.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::HashSet;

--- a/launchk/src/tui/service_list/view.rs
+++ b/launchk/src/tui/service_list/view.rs
@@ -9,6 +9,8 @@ use std::time::Duration;
 use cursive::direction::Direction;
 use cursive::view::ViewWrapper;
 use cursive::{Cursive, View, XY};
+use cursive::event::EventResult;
+use cursive::view::CannotFocus;
 
 use tokio::runtime::Handle;
 use tokio::time::interval;
@@ -357,8 +359,8 @@ impl ViewWrapper for ServiceListView {
         }
     }
 
-    fn wrap_take_focus(&mut self, _: Direction) -> bool {
-        true
+    fn wrap_take_focus(&mut self, _: Direction) -> Result<EventResult, CannotFocus> {
+        Ok(EventResult::Consumed(None))
     }
 }
 

--- a/launchk/src/tui/service_list/view.rs
+++ b/launchk/src/tui/service_list/view.rs
@@ -18,7 +18,6 @@ use tokio::runtime::Handle;
 use tokio::time::interval;
 use xpc_sys::enums::{DomainType, SessionType};
 
-
 use crate::launchd::job_type_filter::JobTypeFilter;
 use crate::launchd::plist::{edit_and_replace, LaunchdEntryLocation, LABEL_TO_ENTRY_CONFIG};
 use crate::launchd::query::procinfo;

--- a/launchk/src/tui/service_list/view.rs
+++ b/launchk/src/tui/service_list/view.rs
@@ -7,15 +7,15 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use cursive::direction::Direction;
-use cursive::view::ViewWrapper;
-use cursive::{Cursive, View, XY};
 use cursive::event::EventResult;
 use cursive::view::CannotFocus;
+use cursive::view::ViewWrapper;
+use cursive::{Cursive, View, XY};
 
 use tokio::runtime::Handle;
 use tokio::time::interval;
-use xpc_sys::objects::unix_fifo::UnixFifo;
 use xpc_sys::enums::{DomainType, SessionType};
+use xpc_sys::objects::unix_fifo::UnixFifo;
 
 use crate::launchd::job_type_filter::JobTypeFilter;
 use crate::launchd::plist::{edit_and_replace, LABEL_TO_ENTRY_CONFIG};

--- a/launchk/src/tui/service_list/view.rs
+++ b/launchk/src/tui/service_list/view.rs
@@ -18,7 +18,7 @@ use sudo::RunningAs;
 use tokio::runtime::Handle;
 use tokio::time::interval;
 use xpc_sys::enums::{DomainType, SessionType};
-use xpc_sys::objects::unix_fifo::UnixFifo;
+
 
 use crate::launchd::job_type_filter::JobTypeFilter;
 use crate::launchd::plist::{edit_and_replace, LaunchdEntryLocation, LABEL_TO_ENTRY_CONFIG};
@@ -239,8 +239,8 @@ impl ServiceListView {
 
         let need_escalate = plist
             .map(|LaunchdPlist { entry_location, .. }| {
-                (entry_location == LaunchdEntryLocation::System
-                    || entry_location == LaunchdEntryLocation::Global)
+                entry_location == LaunchdEntryLocation::System
+                    || entry_location == LaunchdEntryLocation::Global
             })
             .unwrap_or(true);
 

--- a/launchk/src/tui/sysinfo.rs
+++ b/launchk/src/tui/sysinfo.rs
@@ -1,11 +1,11 @@
-use std::cell::Cell;
 
-use cursive::theme::PaletteColor::HighlightText;
+
+
 use cursive::theme::{BaseColor, Color, Effect, Style};
 use cursive::utils::markup::StyledString;
-use cursive::view::ViewWrapper;
-use cursive::views::{DummyView, LinearLayout, PaddedView, ResizedView, TextView};
-use cursive::{Printer, Vec2, View, XY};
+
+use cursive::views::{LinearLayout, ResizedView, TextView};
+
 use sudo::RunningAs;
 use xpc_sys::csr::{csr_check, CsrConfig};
 use xpc_sys::rs_sysctlbyname;

--- a/launchk/src/tui/sysinfo.rs
+++ b/launchk/src/tui/sysinfo.rs
@@ -2,20 +2,50 @@ use std::cell::Cell;
 
 use cursive::theme::{BaseColor, Color, Effect, Style};
 use cursive::{Printer, Vec2, View, XY};
+use cursive::theme::PaletteColor::HighlightText;
+use cursive::utils::markup::StyledString;
+use cursive::view::ViewWrapper;
+use cursive::views::{DummyView, LinearLayout, TextView, PaddedView, ResizedView};
 use xpc_sys::csr::{csr_check, CsrConfig};
 use xpc_sys::rs_sysctlbyname;
 
 pub struct SysInfo {
     current_size: Cell<XY<usize>>,
+    pub layout: LinearLayout,
 }
 
 impl Default for SysInfo {
     fn default() -> Self {
+        let bold = Style::from(Color::Light(BaseColor::White)).combine(Effect::Bold);
+        let mut layout = LinearLayout::horizontal();
+
+        let mut macos = StyledString::styled("macOS: ", bold);
+        let osproductversion =
+            unsafe { rs_sysctlbyname("kern.osproductversion").unwrap_or("".to_string()) };
+        let osversion = unsafe { rs_sysctlbyname("kern.osversion").unwrap_or("".to_string()) };
+        macos.append_plain(format!("{} ({})", osproductversion, osversion));
+
+        layout.add_child(ResizedView::with_full_width(TextView::new(macos)));
+
+        // If granted CSR_ALLOW_UNTRUSTED_KEXTS, SIP is probably off
+        let mut sip = StyledString::styled("SIP: ", bold);
+        let sip_data = unsafe {
+            format!(
+                "{}",
+                csr_check(CsrConfig::ALLOW_UNTRUSTED_KEXTS.bits()) != 0
+            )
+        };
+        sip.append_plain(sip_data);
+
+        layout.add_child(ResizedView::with_full_width(TextView::new(sip)));
+
         Self {
             current_size: Cell::new(XY::new(0, 0)),
+            layout
         }
     }
 }
+
 
 impl View for SysInfo {
     fn draw(&self, printer: &Printer<'_, '_>) {
@@ -43,6 +73,7 @@ impl View for SysInfo {
         printer.print(XY::new(mac_os_label.chars().count() + 1, 0), &mac_os_data);
 
         printer.with_style(bold, |p| p.print(XY::new(middle, 0), sip_label));
+
         printer.print(
             XY::new(middle + sip_label.chars().count() + 1, 0),
             &sip_data,

--- a/launchk/src/tui/sysinfo.rs
+++ b/launchk/src/tui/sysinfo.rs
@@ -6,85 +6,39 @@ use cursive::theme::PaletteColor::HighlightText;
 use cursive::utils::markup::StyledString;
 use cursive::view::ViewWrapper;
 use cursive::views::{DummyView, LinearLayout, TextView, PaddedView, ResizedView};
+use sudo::RunningAs;
 use xpc_sys::csr::{csr_check, CsrConfig};
 use xpc_sys::rs_sysctlbyname;
 
-pub struct SysInfo {
-    current_size: Cell<XY<usize>>,
-    pub layout: LinearLayout,
-}
+pub fn make_layout() -> LinearLayout {
+    let bold = Style::from(Color::Light(BaseColor::White)).combine(Effect::Bold);
+    let mut layout = LinearLayout::horizontal();
 
-impl Default for SysInfo {
-    fn default() -> Self {
-        let bold = Style::from(Color::Light(BaseColor::White)).combine(Effect::Bold);
-        let mut layout = LinearLayout::horizontal();
+    let mut macos = StyledString::styled("macOS: ", bold);
+    let osproductversion =
+        unsafe { rs_sysctlbyname("kern.osproductversion").unwrap_or("".to_string()) };
+    let osversion = unsafe { rs_sysctlbyname("kern.osversion").unwrap_or("".to_string()) };
+    macos.append_plain(format!("{} ({})", osproductversion, osversion));
 
-        let mut macos = StyledString::styled("macOS: ", bold);
-        let osproductversion =
-            unsafe { rs_sysctlbyname("kern.osproductversion").unwrap_or("".to_string()) };
-        let osversion = unsafe { rs_sysctlbyname("kern.osversion").unwrap_or("".to_string()) };
-        macos.append_plain(format!("{} ({})", osproductversion, osversion));
-
-        layout.add_child(ResizedView::with_full_width(TextView::new(macos)));
-
-        // If granted CSR_ALLOW_UNTRUSTED_KEXTS, SIP is probably off
-        let mut sip = StyledString::styled("SIP: ", bold);
-        let sip_data = unsafe {
-            format!(
-                "{}",
-                csr_check(CsrConfig::ALLOW_UNTRUSTED_KEXTS.bits()) != 0
-            )
-        };
-        sip.append_plain(sip_data);
-
-        layout.add_child(ResizedView::with_full_width(TextView::new(sip)));
-
-        Self {
-            current_size: Cell::new(XY::new(0, 0)),
-            layout
-        }
-    }
-}
-
-
-impl View for SysInfo {
-    fn draw(&self, printer: &Printer<'_, '_>) {
-        let middle = self.current_size.get().x / 2;
-
-        let mac_os_label = "macOS:";
-        let osproductversion =
-            unsafe { rs_sysctlbyname("kern.osproductversion").unwrap_or("".to_string()) };
-        let osversion = unsafe { rs_sysctlbyname("kern.osversion").unwrap_or("".to_string()) };
-        let mac_os_data = format!("{} ({})", osproductversion, osversion);
-
-        // If granted CSR_ALLOW_UNTRUSTED_KEXTS, SIP is probably off
-        let sip_label = "SIP:";
-        let sip_data = unsafe {
-            format!(
-                "{}",
-                csr_check(CsrConfig::ALLOW_UNTRUSTED_KEXTS.bits()) != 0
-            )
-        };
-
-        let bold = Style::from(Color::Light(BaseColor::White));
-        let bold = bold.combine(Effect::Bold);
-
-        printer.with_style(bold, |p| p.print(XY::new(0, 0), mac_os_label));
-        printer.print(XY::new(mac_os_label.chars().count() + 1, 0), &mac_os_data);
-
-        printer.with_style(bold, |p| p.print(XY::new(middle, 0), sip_label));
-
-        printer.print(
-            XY::new(middle + sip_label.chars().count() + 1, 0),
-            &sip_data,
-        );
+    if sudo::check() == RunningAs::Root {
+        macos.append_styled(" (root)", bold.combine(Color::Light(BaseColor::Red)));
     }
 
-    fn layout(&mut self, size: Vec2) {
-        self.current_size.replace(size);
-    }
+    layout.add_child(ResizedView::with_full_width(TextView::new(macos)));
 
-    fn required_size(&mut self, constraint: XY<usize>) -> XY<usize> {
-        XY::new(constraint.x, 1)
-    }
+    // If granted CSR_ALLOW_UNTRUSTED_KEXTS, SIP is probably off
+    let mut sip = StyledString::styled("SIP: ", bold);
+    let sip_data = unsafe {
+        format!(
+            "{}",
+            csr_check(CsrConfig::ALLOW_UNTRUSTED_KEXTS.bits()) != 0
+        )
+    };
+    sip.append_plain(sip_data);
+
+    layout.add_child(ResizedView::with_full_width(TextView::new(sip)));
+
+
+
+    layout
 }

--- a/launchk/src/tui/sysinfo.rs
+++ b/launchk/src/tui/sysinfo.rs
@@ -1,6 +1,3 @@
-
-
-
 use cursive::theme::{BaseColor, Color, Effect, Style};
 use cursive::utils::markup::StyledString;
 

--- a/launchk/src/tui/sysinfo.rs
+++ b/launchk/src/tui/sysinfo.rs
@@ -1,11 +1,11 @@
 use std::cell::Cell;
 
-use cursive::theme::{BaseColor, Color, Effect, Style};
-use cursive::{Printer, Vec2, View, XY};
 use cursive::theme::PaletteColor::HighlightText;
+use cursive::theme::{BaseColor, Color, Effect, Style};
 use cursive::utils::markup::StyledString;
 use cursive::view::ViewWrapper;
-use cursive::views::{DummyView, LinearLayout, TextView, PaddedView, ResizedView};
+use cursive::views::{DummyView, LinearLayout, PaddedView, ResizedView, TextView};
+use cursive::{Printer, Vec2, View, XY};
 use sudo::RunningAs;
 use xpc_sys::csr::{csr_check, CsrConfig};
 use xpc_sys::rs_sysctlbyname;
@@ -37,8 +37,6 @@ pub fn make_layout() -> LinearLayout {
     sip.append_plain(sip_data);
 
     layout.add_child(ResizedView::with_full_width(TextView::new(sip)));
-
-
 
     layout
 }

--- a/launchk/src/tui/table/table_list_view.rs
+++ b/launchk/src/tui/table/table_list_view.rs
@@ -3,8 +3,8 @@ use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::rc::Rc;
 
-use std::sync::Arc;
 use std::collections::hash_map::DefaultHasher;
+use std::sync::Arc;
 
 use cursive::event::{Event, EventResult};
 use cursive::traits::{Resizable, Scrollable};
@@ -26,7 +26,7 @@ pub struct TableListView<T> {
     linear_layout: LinearLayout,
     // LinearLayout swallows T from , but we still need it
     inner: PhantomData<T>,
-    last_hash: RefCell<u64>
+    last_hash: RefCell<u64>,
 }
 
 impl<T: 'static + TableListItem> TableListView<T> {
@@ -59,14 +59,14 @@ impl<T: 'static + TableListItem> TableListView<T> {
             linear_layout,
             column_sizer,
             inner: PhantomData::default(),
-            last_hash
+            last_hash,
         }
     }
 
     pub fn replace_and_preserve_selection<I>(&mut self, items: I)
     where
         I: IntoIterator<Item = T>,
-        T: Hash
+        T: Hash,
     {
         let rows: Vec<(String, T)> = items
             .into_iter()
@@ -92,13 +92,15 @@ impl<T: 'static + TableListItem> TableListView<T> {
         rows.hash(&mut row_hasher);
         let hash = row_hasher.finish();
 
-        if *self.last_hash.borrow() == hash { return }
+        if *self.last_hash.borrow() == hash {
+            return;
+        }
         log::trace!("Replaced listview items -- new hash {}", hash);
         *self.last_hash.borrow_mut() = hash;
 
         let sv = self.get_mut_selectview();
         let current_selection = sv.selected_id().unwrap_or(0);
-        
+
         sv.clear();
         sv.add_all(rows);
         sv.set_selection(current_selection);

--- a/xpc-sys/Cargo.toml
+++ b/xpc-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xpc-sys"
 description = "Conveniently call routines with wrappers for xpc_pipe_routine() and go from Rust types to XPC objects and back!"
-version = "0.4.2"
+version = "0.4.1"
 authors = ["David Stancu <dstancu@nyu.edu>"]
 license = "MIT"
 edition = "2018"

--- a/xpc-sys/Cargo.toml
+++ b/xpc-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xpc-sys"
 description = "Conveniently call routines with wrappers for xpc_pipe_routine() and go from Rust types to XPC objects and back!"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["David Stancu <dstancu@nyu.edu>"]
 license = "MIT"
 edition = "2018"
@@ -16,9 +16,9 @@ targets = ["x86_64-apple-darwin", "aarch64-apple-darwin"]
 [dependencies]
 block = "0.1.6"
 lazy_static = "1.4.0"
-log = "0.4.14"
-bitflags = "1.3.2"
-libc = "0.2.132"
+log = "0.4.20"
+bitflags = "2.4.0"
+libc = "0.2.147"
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/xpc-sys/Cargo.toml
+++ b/xpc-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xpc-sys"
 description = "Conveniently call routines with wrappers for xpc_pipe_routine() and go from Rust types to XPC objects and back!"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["David Stancu <dstancu@nyu.edu>"]
 license = "MIT"
 edition = "2018"
@@ -11,15 +11,15 @@ categories = ["external-ffi-bindings", "os::macos-apis"]
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu`
 # and only builds that target
-targets = ["x86_64-apple-darwin"]
+targets = ["x86_64-apple-darwin", "aarch64-apple-darwin"]
 
 [dependencies]
 block = "0.1.6"
 lazy_static = "1.4.0"
 log = "0.4.14"
-bitflags = "1.2.1"
-libc = "0.2.94"
+bitflags = "1.3.2"
+libc = "0.2.132"
 
 [build-dependencies]
-bindgen = "0.53.1"
+bindgen = "0.60.1"
 xcrun = "1.0.4"

--- a/xpc-sys/src/csr.rs
+++ b/xpc-sys/src/csr.rs
@@ -1,9 +1,10 @@
-use std::os::raw::c_int;
+use std::{os::raw::c_int, fmt, fmt::Formatter};
 
 pub type csr_config_t = u32;
 
 // https://github.com/apple/darwin-xnu/blob/main/bsd/kern/kern_csr.c
 bitflags! {
+    #[derive(PartialEq, Eq)]
     pub struct CsrConfig: csr_config_t {
         const ALLOW_UNTRUSTED_KEXTS = 1 << 0;
         const ALLOW_UNRESTRICTED_FS = 1 << 1;
@@ -18,6 +19,26 @@ bitflags! {
         const ALLOW_UNAPPROVED_KEXTS = 1 << 9;
         const ALLOW_EXECUTABLE_POLICY_OVERRIDE = 1 << 10;
         const ALLOW_UNAUTHENTICATED_ROOT = 1 << 11;
+    }
+}
+
+impl fmt::Debug for CsrConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            CsrConfig::ALLOW_UNTRUSTED_KEXTS => write!(f, "ALLOW_UNTRUSTED_KEXTS"),
+            CsrConfig::ALLOW_UNRESTRICTED_FS => write!(f, "ALLOW_UNRESTRICTED_FS"),
+            CsrConfig::ALLOW_TASK_FOR_PID => write!(f, "ALLOW_TASK_FOR_PID"),
+            CsrConfig::ALLOW_KERNEL_DEBUGGER => write!(f, "ALLOW_KERNEL_DEBUGGER"),
+            CsrConfig::ALLOW_APPLE_INTERNAL => write!(f, "ALLOW_APPLE_INTERNAL"),
+            CsrConfig::ALLOW_DESTRUCTIVE_DTRACE => write!(f, "ALLOW_DESTRUCTIVE_DTRACE | ALLOW_UNRESTRICTED_DTRACE"),
+            CsrConfig::ALLOW_UNRESTRICTED_NVRAM => write!(f, "ALLOW_UNRESTRICTED_NVRAM"),
+            CsrConfig::ALLOW_DEVICE_CONFIGURATION => write!(f, "ALLOW_DEVICE_CONFIGURATION"),
+            CsrConfig::ALLOW_ANY_RECOVERY_OS => write!(f, "ALLOW_ANY_RECOVERY_OS"),
+            CsrConfig::ALLOW_UNAPPROVED_KEXTS => write!(f, "ALLOW_UNAPPROVED_KEXTS"),
+            CsrConfig::ALLOW_EXECUTABLE_POLICY_OVERRIDE => write!(f, "ALLOW_EXECUTABLE_POLICY_OVERRIDE"),
+            CsrConfig::ALLOW_UNAUTHENTICATED_ROOT => write!(f, "ALLOW_UNAUTHENTICATED_ROOT"),
+            _ => Ok(())
+        }
     }
 }
 

--- a/xpc-sys/src/csr.rs
+++ b/xpc-sys/src/csr.rs
@@ -1,4 +1,4 @@
-use std::{os::raw::c_int, fmt, fmt::Formatter};
+use std::{fmt, fmt::Formatter, os::raw::c_int};
 
 pub type csr_config_t = u32;
 
@@ -30,14 +30,18 @@ impl fmt::Debug for CsrConfig {
             CsrConfig::ALLOW_TASK_FOR_PID => write!(f, "ALLOW_TASK_FOR_PID"),
             CsrConfig::ALLOW_KERNEL_DEBUGGER => write!(f, "ALLOW_KERNEL_DEBUGGER"),
             CsrConfig::ALLOW_APPLE_INTERNAL => write!(f, "ALLOW_APPLE_INTERNAL"),
-            CsrConfig::ALLOW_DESTRUCTIVE_DTRACE => write!(f, "ALLOW_DESTRUCTIVE_DTRACE | ALLOW_UNRESTRICTED_DTRACE"),
+            CsrConfig::ALLOW_DESTRUCTIVE_DTRACE => {
+                write!(f, "ALLOW_DESTRUCTIVE_DTRACE | ALLOW_UNRESTRICTED_DTRACE")
+            }
             CsrConfig::ALLOW_UNRESTRICTED_NVRAM => write!(f, "ALLOW_UNRESTRICTED_NVRAM"),
             CsrConfig::ALLOW_DEVICE_CONFIGURATION => write!(f, "ALLOW_DEVICE_CONFIGURATION"),
             CsrConfig::ALLOW_ANY_RECOVERY_OS => write!(f, "ALLOW_ANY_RECOVERY_OS"),
             CsrConfig::ALLOW_UNAPPROVED_KEXTS => write!(f, "ALLOW_UNAPPROVED_KEXTS"),
-            CsrConfig::ALLOW_EXECUTABLE_POLICY_OVERRIDE => write!(f, "ALLOW_EXECUTABLE_POLICY_OVERRIDE"),
+            CsrConfig::ALLOW_EXECUTABLE_POLICY_OVERRIDE => {
+                write!(f, "ALLOW_EXECUTABLE_POLICY_OVERRIDE")
+            }
             CsrConfig::ALLOW_UNAUTHENTICATED_ROOT => write!(f, "ALLOW_UNAUTHENTICATED_ROOT"),
-            _ => Ok(())
+            _ => Ok(()),
         }
     }
 }

--- a/xpc-sys/src/enums.rs
+++ b/xpc-sys/src/enums.rs
@@ -10,7 +10,7 @@ use crate::traits::xpc_value::TryXPCValue;
 
 /// LimitLoadToSessionType key in XPC response
 /// https://developer.apple.com/library/archive/technotes/tn2083/_index.html
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum SessionType {
     Aqua = 0,
     StandardIO,
@@ -70,7 +70,7 @@ impl TryFrom<Arc<XPCObject>> for SessionType {
 }
 
 // Huge thanks to: https://saelo.github.io/presentations/bits_of_launchd.pdf
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum DomainType {
     System = 1,
     User = 2,

--- a/xpc-sys/src/lib.rs
+++ b/xpc-sys/src/lib.rs
@@ -16,9 +16,9 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 //
 pub mod csr;
+pub mod enums;
 pub mod objects;
 pub mod traits;
-pub mod enums;
 //
 
 pub type xpc_pipe_t = *mut c_void;

--- a/xpc-sys/src/lib.rs
+++ b/xpc-sys/src/lib.rs
@@ -173,6 +173,10 @@ pub unsafe fn rs_sysctlbyname(name: &str) -> Result<String, String> {
     }
 }
 
+pub fn rs_geteuid() -> uid_t {
+    unsafe { geteuid() }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/xpc-sys/src/lib.rs
+++ b/xpc-sys/src/lib.rs
@@ -23,10 +23,10 @@ pub mod traits;
 
 pub type xpc_pipe_t = *mut c_void;
 
-/// Some extra private API definitions. Thanks:
-///
-/// https://developer.apple.com/documentation/kernel/mach
-/// https://chromium.googlesource.com/chromium/src.git/+/47.0.2507.2/sandbox/mac/xpc_private_stubs.sig
+// Some extra private API definitions. Thanks:
+//
+// https://developer.apple.com/documentation/kernel/mach
+// https://chromium.googlesource.com/chromium/src.git/+/47.0.2507.2/sandbox/mac/xpc_private_stubs.sig
 extern "C" {
     // Can decode i64 returned in "errors" for XPC responses
     pub fn xpc_strerror(err: c_int) -> *const c_char;

--- a/xpc-sys/src/traits/mod.rs
+++ b/xpc-sys/src/traits/mod.rs
@@ -1,3 +1,3 @@
+pub mod query_builder;
 pub mod xpc_pipeable;
 pub mod xpc_value;
-pub mod query_builder;


### PR DESCRIPTION
So far:

- [x] Apple Silicon no longer needs to edit target triplets to build
- [x] Latest version of cursive, notify
- [x] Fix latency of chained commands
- [x] Simplify fsnotify impl: [no more precise events](https://github.com/notify-rs/notify/blob/main/UPGRADING_V4_TO_V5.md#precise-events--debouncing), which is fine for us since we are looking to see if file changed or new file appeared (can just consume path and reload)
- [x] No longer query unsupported domains for main list poller
- [x] `sudo` for anything requiring escalation, sysinfo shows you when you are root

TODO:

- [x] procinfo errno 22 invalid argument??