### PR TITLE
Update bindgen, use libc for symbols available in it and filter the symbols in the generated bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,17 +50,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,24 +78,24 @@ checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "9ffcebc3849946a7170a05992aac39da343a90676ab392c51a4280981d6379c2"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cexpr",
  "clang-sys",
- "clap",
- "env_logger 0.9.0",
  "lazy_static",
  "lazycell",
  "log",
  "peeking_take_while",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 2.0.32",
  "which",
 ]
 
@@ -164,30 +153,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "clap"
-version = "3.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_lex",
- "indexmap",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -368,19 +333,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
@@ -496,7 +448,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -681,7 +633,7 @@ dependencies = [
  "bitflags 2.4.0",
  "clearscreen",
  "cursive",
- "env_logger 0.10.0",
+ "env_logger",
  "futures",
  "git-version",
  "lazy_static",
@@ -968,12 +920,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
-
-[[package]]
 name = "owning_ref"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1025,16 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1287,12 +1243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "sudo"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1357,12 +1307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
-
-[[package]]
 name = "thiserror"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,7 +1323,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1420,7 +1364,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]

--- a/xpc-sys/Cargo.toml
+++ b/xpc-sys/Cargo.toml
@@ -21,5 +21,5 @@ bitflags = "2.4.0"
 libc = "0.2.147"
 
 [build-dependencies]
-bindgen = "0.60.1"
+bindgen = "0.69.1"
 xcrun = "1.0.4"

--- a/xpc-sys/build.rs
+++ b/xpc-sys/build.rs
@@ -16,8 +16,6 @@ fn main() {
 
     let xpc_path = format!("{}{}/xpc/xpc.h", sdk_path, MACOS_INCLUDE_PATH);
     let bootstrap_path = format!("{}{}/bootstrap.h", sdk_path, MACOS_INCLUDE_PATH);
-    let sys_types = format!("{}{}/sys/types.h", sdk_path, MACOS_INCLUDE_PATH);
-    let sysctl = format!("{}{}/sys/sysctl.h", sdk_path, MACOS_INCLUDE_PATH);
 
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
@@ -27,8 +25,6 @@ fn main() {
         // bindings for.
         .header(xpc_path)
         .header(bootstrap_path)
-        .header(sys_types)
-        .header(sysctl)
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))

--- a/xpc-sys/build.rs
+++ b/xpc-sys/build.rs
@@ -25,6 +25,13 @@ fn main() {
         // bindings for.
         .header(xpc_path)
         .header(bootstrap_path)
+        // Filter the results to only relevant symbols
+        .allowlist_function("^xpc_.*")
+        .allowlist_var("^_xpc_.*")
+        .allowlist_var("^bootstrap_port")
+        // The following symbols should probably be in libc or mach2, but are not
+        .allowlist_function("^mach_port.*")
+        .allowlist_function("^vm_allocate")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))

--- a/xpc-sys/build.rs
+++ b/xpc-sys/build.rs
@@ -31,7 +31,7 @@ fn main() {
         .header(sysctl)
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.

--- a/xpc-sys/src/lib.rs
+++ b/xpc-sys/src/lib.rs
@@ -155,7 +155,7 @@ pub unsafe fn read_xpc_global_data() -> Option<&'static xpc_global_data> {
 pub unsafe fn rs_sysctlbyname(name: &str) -> Result<String, String> {
     let name = CString::new(name).unwrap();
     let mut ret_buf: [c_char; 256] = [0; 256];
-    let mut size = ret_buf.len() as u64;
+    let mut size = ret_buf.len();
 
     let err = sysctlbyname(
         name.as_ptr(),

--- a/xpc-sys/src/lib.rs
+++ b/xpc-sys/src/lib.rs
@@ -8,6 +8,7 @@ extern crate lazy_static;
 #[macro_use]
 extern crate bitflags;
 
+use libc::{geteuid, mach_task_self_, strerror, sysctlbyname, KERN_SUCCESS, MACH_PORT_NULL};
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_long, c_void};
 use std::ptr::null_mut;
@@ -68,8 +69,8 @@ pub struct _os_alloc_once_s {
 
 #[repr(C)]
 pub struct xpc_global_data {
-    pub a: u_int64_t,
-    pub xpc_flags: u_int64_t,
+    pub a: u64,
+    pub xpc_flags: u64,
     pub task_bootstrap_port: mach_port_t,
     pub xpc_bootstrap_pipe: xpc_pipe_t,
 }
@@ -88,7 +89,7 @@ pub fn rs_strerror(err: i32) -> String {
 
 /// Attempt to yield existing bootstrap_port if not MACH_PORT_NULL
 pub unsafe fn get_bootstrap_port() -> mach_port_t {
-    if bootstrap_port == MACH_PORT_NULL {
+    if bootstrap_port == MACH_PORT_NULL as mach_port_t {
         log::debug!("Bootstrap port is null! Querying for port");
         lookup_bootstrap_port()
     } else {

--- a/xpc-sys/src/lib.rs
+++ b/xpc-sys/src/lib.rs
@@ -8,6 +8,7 @@ extern crate lazy_static;
 #[macro_use]
 extern crate bitflags;
 
+pub use libc::MAP_SHARED;
 use libc::{geteuid, mach_task_self_, strerror, sysctlbyname, KERN_SUCCESS, MACH_PORT_NULL};
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_long, c_void};

--- a/xpc-sys/src/objects/xpc_object.rs
+++ b/xpc-sys/src/objects/xpc_object.rs
@@ -2,10 +2,11 @@ use libc::c_int;
 
 use crate::objects::xpc_type::XPCType;
 use crate::{
-    mach_port_t, xpc_array_append_value, xpc_array_create, xpc_bool_create, xpc_copy,
-    xpc_copy_description, xpc_double_create, xpc_fd_create, xpc_int64_create, xpc_mach_recv_create,
-    xpc_mach_send_create, xpc_object_t, xpc_release, xpc_string_create, xpc_uint64_create,
+    xpc_array_append_value, xpc_array_create, xpc_bool_create, xpc_copy, xpc_copy_description,
+    xpc_double_create, xpc_fd_create, xpc_int64_create, xpc_mach_recv_create, xpc_mach_send_create,
+    xpc_object_t, xpc_release, xpc_string_create, xpc_uint64_create,
 };
+use libc::mach_port_t;
 use std::ffi::{CStr, CString};
 use std::os::unix::prelude::RawFd;
 use std::ptr::null_mut;

--- a/xpc-sys/src/objects/xpc_shmem.rs
+++ b/xpc-sys/src/objects/xpc_shmem.rs
@@ -1,9 +1,7 @@
 use crate::objects::xpc_error::XPCError;
 use crate::objects::xpc_object::XPCObject;
-use crate::{
-    mach_port_t, mach_task_self_, rs_strerror, vm_address_t, vm_allocate, vm_deallocate, vm_size_t,
-    xpc_shmem_create,
-};
+use crate::{rs_strerror, vm_allocate, xpc_shmem_create};
+use libc::{mach_port_t, mach_task_self_, vm_address_t, vm_deallocate, vm_size_t};
 use std::ffi::c_void;
 use std::os::raw::c_int;
 use std::ptr::null_mut;

--- a/xpc-sys/src/objects/xpc_shmem.rs
+++ b/xpc-sys/src/objects/xpc_shmem.rs
@@ -39,7 +39,7 @@ impl XPCShmem {
             Err(XPCError::IOError(rs_strerror(err)))
         } else {
             let xpc_object: XPCObject =
-                unsafe { xpc_shmem_create(region as *mut c_void, size as u64).into() };
+                unsafe { xpc_shmem_create(region as *mut c_void, size).into() };
 
             log::info!(
                 "XPCShmem new (region: {:p}, xpc_object_t {:p})",

--- a/xpc-sys/src/traits/query_builder.rs
+++ b/xpc-sys/src/traits/query_builder.rs
@@ -1,8 +1,9 @@
 use crate::enums::{DomainType, SessionType};
+use crate::get_bootstrap_port;
 use crate::objects::xpc_dictionary::XPCDictionary;
 use crate::objects::xpc_object::MachPortType;
 use crate::objects::xpc_object::XPCObject;
-use crate::{get_bootstrap_port, mach_port_t};
+use libc::mach_port_t;
 
 /// Builder methods for XPCDictionary to make querying easier
 pub trait QueryBuilder {

--- a/xpc-sys/src/traits/xpc_value.rs
+++ b/xpc-sys/src/traits/xpc_value.rs
@@ -6,10 +6,11 @@ use std::rc::Rc;
 use crate::objects::xpc_object::{MachPortType, XPCObject};
 use crate::objects::xpc_type;
 use crate::{
-    mach_port_t, xpc_array_apply, xpc_bool_get_value, xpc_double_get_value,
-    xpc_int64_get_value, xpc_mach_send_get_right, xpc_object_t, xpc_string_get_string_ptr,
-    xpc_type_get_name, xpc_uint64_get_value,
+    xpc_array_apply, xpc_bool_get_value, xpc_double_get_value, xpc_int64_get_value,
+    xpc_mach_send_get_right, xpc_object_t, xpc_string_get_string_ptr, xpc_type_get_name,
+    xpc_uint64_get_value,
 };
+use libc::mach_port_t;
 
 use crate::objects::xpc_error::XPCError;
 use crate::objects::xpc_error::XPCError::ValueError;
@@ -121,12 +122,12 @@ impl TryXPCValue<Vec<Arc<XPCObject>>> for XPCObject {
 #[cfg(test)]
 mod tests {
     use crate::get_bootstrap_port;
-    use crate::mach_port_t;
     use crate::objects::xpc_error::XPCError;
     use crate::objects::xpc_error::XPCError::ValueError;
     use crate::objects::xpc_object::MachPortType;
     use crate::objects::xpc_object::XPCObject;
     use crate::traits::xpc_value::TryXPCValue;
+    use libc::mach_port_t;
     use std::sync::Arc;
 
     #[test]

--- a/xpc-sys/src/traits/xpc_value.rs
+++ b/xpc-sys/src/traits/xpc_value.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use crate::objects::xpc_object::{MachPortType, XPCObject};
 use crate::objects::xpc_type;
 use crate::{
-    mach_port_t, size_t, xpc_array_apply, xpc_bool_get_value, xpc_double_get_value,
+    mach_port_t, xpc_array_apply, xpc_bool_get_value, xpc_double_get_value,
     xpc_int64_get_value, xpc_mach_send_get_right, xpc_object_t, xpc_string_get_string_ptr,
     xpc_type_get_name, xpc_uint64_get_value,
 };
@@ -95,7 +95,7 @@ impl TryXPCValue<Vec<Arc<XPCObject>>> for XPCObject {
         let vec: Rc<RefCell<Vec<Arc<XPCObject>>>> = Rc::new(RefCell::new(vec![]));
         let vec_rc_clone = vec.clone();
 
-        let block = ConcreteBlock::new(move |_: size_t, obj: xpc_object_t| {
+        let block = ConcreteBlock::new(move |_: usize, obj: xpc_object_t| {
             let xpc_object: XPCObject = XPCObject::xpc_copy(obj);
             vec_rc_clone.borrow_mut().push(xpc_object.into());
             true


### PR DESCRIPTION
There are three commits in here

1. Updates bindgen, this means that size_t -> usize, so change some types
2. Update some bindings to use libc types rather than auto generated types (since we already have libc)
3. Update build.rs to filter which symbols are available in the bindings