### PR TITLE
xpc-sys: Don't xpc_release NULLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,7 +1648,7 @@ checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
 name = "xpc-sys"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bindgen",
  "bitflags 2.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,7 +1648,7 @@ checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
 name = "xpc-sys"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bindgen",
  "bitflags 2.4.0",

--- a/xpc-sys/Cargo.toml
+++ b/xpc-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xpc-sys"
 description = "Conveniently call routines with wrappers for xpc_pipe_routine() and go from Rust types to XPC objects and back!"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["David Stancu <dstancu@nyu.edu>"]
 license = "MIT"
 edition = "2018"

--- a/xpc-sys/Cargo.toml
+++ b/xpc-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xpc-sys"
 description = "Conveniently call routines with wrappers for xpc_pipe_routine() and go from Rust types to XPC objects and back!"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["David Stancu <dstancu@nyu.edu>"]
 license = "MIT"
 edition = "2018"

--- a/xpc-sys/src/objects/xpc_object.rs
+++ b/xpc-sys/src/objects/xpc_object.rs
@@ -98,7 +98,7 @@ impl fmt::Display for XPCObject {
         let XPCObject(ptr, _) = self;
 
         if *ptr == null_mut() {
-            write!(f, "XPCObject is NULL")
+            write!(f, "{:?} xpc_object_t is NULL", self)
         } else {
             let xpc_desc = unsafe { xpc_copy_description(*ptr) };
             let cstr = unsafe { CStr::from_ptr(xpc_desc) };
@@ -222,7 +222,7 @@ impl Drop for XPCObject {
         let XPCObject(ptr, _) = &self;
 
         if *ptr == null_mut() {
-            log::info!("XPCObject drop null -- will not call xpc_release() (default?)");
+            log::info!("XPCObject xpc_object_t is NULL, not calling xpc_release() (Default?)");
             return 
         }
 
@@ -266,5 +266,19 @@ mod tests {
         ] {
             assert!(obj.get_refs().is_some())
         }
+    }
+
+    #[test]
+    fn drop_default() {
+        let my_obj = XPCObject::default();
+        drop(my_obj);
+    }
+
+    #[test]
+    fn display_default() {
+        let my_obj = XPCObject::default();
+        assert!(
+            format!("{}", my_obj) == "XPCObject(0x0, XPCType(0x0)) xpc_object_t is NULL"
+        );
     }
 }

--- a/xpc-sys/src/objects/xpc_object.rs
+++ b/xpc-sys/src/objects/xpc_object.rs
@@ -216,7 +216,7 @@ impl Drop for XPCObject {
         let XPCObject(ptr, _) = &self;
 
         if *ptr == null_mut() {
-            log::info!("XPCObject xpc_object_t is NULL, not calling xpc_release() (Default?)");
+            log::info!("XPCObject xpc_object_t is NULL, not calling xpc_release()");
             return 
         }
 

--- a/xpc-sys/src/objects/xpc_object.rs
+++ b/xpc-sys/src/objects/xpc_object.rs
@@ -220,6 +220,12 @@ impl Drop for XPCObject {
     /// https://developer.apple.com/documentation/xpc/1505851-xpc_release
     fn drop(&mut self) {
         let XPCObject(ptr, _) = &self;
+
+        if *ptr == null_mut() {
+            log::info!("XPCObject drop null -- will not call xpc_release() (default?)");
+            return 
+        }
+
         log::info!(
             "XPCObject drop ({:p}, {}, {})",
             *ptr,
@@ -229,6 +235,7 @@ impl Drop for XPCObject {
                 .map(|(r, xr)| format!("refs {} xrefs {}", r, xr))
                 .unwrap_or("refs ???".to_string()),
         );
+
         unsafe { xpc_release(*ptr) }
     }
 }

--- a/xpc-sys/src/objects/xpc_object.rs
+++ b/xpc-sys/src/objects/xpc_object.rs
@@ -85,12 +85,6 @@ impl XPCObject {
     }
 }
 
-impl Default for XPCObject {
-    fn default() -> Self {
-        Self(null_mut(), XPCType(null_mut()))
-    }
-}
-
 impl fmt::Display for XPCObject {
     /// Use xpc_copy_description to show as a string, for
     /// _xpc_type_dictionary contents are shown!
@@ -266,19 +260,5 @@ mod tests {
         ] {
             assert!(obj.get_refs().is_some())
         }
-    }
-
-    #[test]
-    fn drop_default() {
-        let my_obj = XPCObject::default();
-        drop(my_obj);
-    }
-
-    #[test]
-    fn display_default() {
-        let my_obj = XPCObject::default();
-        assert!(
-            format!("{}", my_obj) == "XPCObject(0x0, XPCType(0x0)) xpc_object_t is NULL"
-        );
     }
 }

--- a/xpc-sys/src/objects/xpc_type.rs
+++ b/xpc-sys/src/objects/xpc_type.rs
@@ -1,7 +1,7 @@
 use crate::{
     _xpc_type_array, _xpc_type_bool, _xpc_type_dictionary, _xpc_type_double, _xpc_type_fd,
     _xpc_type_int64, _xpc_type_mach_recv, _xpc_type_mach_send, _xpc_type_s, _xpc_type_shmem,
-    _xpc_type_string, _xpc_type_uint64, xpc_get_type, xpc_object_t, xpc_type_get_name, xpc_type_t,
+    _xpc_type_string, _xpc_type_uint64, xpc_get_type, xpc_object_t, xpc_type_get_name, xpc_type_t, _xpc_type_null,
 };
 
 use crate::objects::xpc_error::XPCError;
@@ -93,6 +93,7 @@ lazy_static! {
         unsafe { (&_xpc_type_mach_recv as *const _xpc_type_s).into() };
     pub static ref Fd: XPCType = unsafe { (&_xpc_type_fd as *const _xpc_type_s).into() };
     pub static ref Shmem: XPCType = unsafe { (&_xpc_type_shmem as *const _xpc_type_s).into() };
+    pub static ref Null: XPCType = unsafe { (&_xpc_type_null as *const _xpc_type_s).into() };
 }
 
 /// Runtime type check for XPC object.


### PR DESCRIPTION
I am not sure that implementing `Default` for XPCObject makes much sense. Options are:
- Get rid of the Default impl
- Return `xpc_null_create()`
- Leave as is and check for NULL `xpc_object_t` (probably a good idea)

Strangely enough nothing bad happens when doing this on Sonoma:
```rust
#[test]
fn release_null() {
    unsafe { xpc_release(null_mut()) }
}
```

```
running 1 test
test objects::xpc_object::tests::release_null ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 23 filtered out; finished in 0.00s
```