### PR TITLE
Always blocklist xpc_dictionary_set_mach_send, add macOS build matrix for CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,32 @@ env:
 
 jobs:
   build:
-
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-12
+            xcode_version: 14.0.1         # macOS SDK: 12.3
+          - runner: macos-12
+            xcode_version: 14.2           # macOS SDK: 13.1
+          - runner: macos-13
+            xcode_version: 15.2           # macOS SDK: 14.2
+          - runner: macos-14
+            xcode_version: 15.3           # macOS SDK: 14.4
+          # optionally opt into latest stable Xcode version in future
+          # - runner: macos-14
+          #   xcode_version: latest-stable
+    runs-on: ${{ matrix.runner }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+    - name: Setup Xcode version
+      uses: maxim-lobanov/setup-xcode@v1.6.0
+      with:
+        xcode-version: ${{ matrix.xcode_version }}
     - name: Build
-      run: cargo build --verbose
+      run: |
+        echo "macOS SDK version: $(xcrun --sdk macosx --show-sdk-version)"
+        cargo build --verbose
     - name: Run tests
       run: cargo test --verbose

--- a/xpc-sys/build.rs
+++ b/xpc-sys/build.rs
@@ -29,6 +29,8 @@ fn main() {
         .allowlist_function("^xpc_.*")
         .allowlist_var("^_xpc_.*")
         .allowlist_var("^bootstrap_port")
+        // This function began appearing as of macOS 14.4 SDK headers
+        .blocklist_function("xpc_dictionary_set_mach_send")
         // The following symbols should probably be in libc or mach2, but are not
         .allowlist_function("^mach_port.*")
         .allowlist_function("^vm_allocate")


### PR DESCRIPTION
As discussed in https://github.com/mach-kernel/launchk/issues/19#issuecomment-2048649340, should fix the build and also add a matrix of macOS SDK versions to build against in CI.