### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/xpc-sys/Cargo.toml
+++ b/xpc-sys/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 edition = "2018"
 keywords = ["apple", "xpc", "xpc-dictionary"]
 categories = ["external-ffi-bindings", "os::macos-apis"]
+repository = "https://github.com/mach-kernel/launchk"
 
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu`


### PR DESCRIPTION
to allow https://crates.io/ , https://lib.rs/ and https://rust-digger.code-maven.com/ to link to it