### PR TITLE
[xpc-sys] use mach2 crate + misc updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +1773,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "mach2",
  "xcrun",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
 name = "xpc-sys"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "bindgen",
  "bitflags 2.9.1",

--- a/launchk/src/launchd/message.rs
+++ b/launchk/src/launchd/message.rs
@@ -1,5 +1,5 @@
 use xpc_sys::objects::xpc_dictionary::XPCDictionary;
-use xpc_sys::traits::query_builder::QueryBuilder;
+use xpc_sys::traits::dict_builder::DictBuilder;
 
 // A bunch of XPCDictionary 'protos' that can be extended to make XPC queries
 

--- a/launchk/src/launchd/query.rs
+++ b/launchk/src/launchd/query.rs
@@ -16,7 +16,7 @@ use crate::launchd::entry_status::ENTRY_STATUS_CACHE;
 use std::iter::FromIterator;
 use xpc_sys::objects::xpc_dictionary::XPCDictionary;
 use xpc_sys::objects::xpc_error::XPCError;
-use xpc_sys::traits::query_builder::QueryBuilder;
+use xpc_sys::traits::dict_builder::DictBuilder;
 
 use xpc_sys::enums::{DomainType, SessionType};
 
@@ -158,7 +158,7 @@ pub fn disable<S: Into<String>>(
 /// dumpstate contents into, and return the bytes written and
 /// shmem region
 pub fn dumpstate() -> Result<(usize, XPCShmem), XPCError> {
-    let shmem = XPCShmem::new_task_self(
+    let shmem = XPCShmem::allocate_task_self(
         0x1400000,
         i32::try_from(MAP_SHARED).expect("Must conv flags"),
     )?;
@@ -174,7 +174,7 @@ pub fn dumpstate() -> Result<(usize, XPCShmem), XPCError> {
 }
 
 pub fn dumpjpcategory() -> Result<(usize, XPCShmem), XPCError> {
-    let shmem = XPCShmem::new_task_self(
+    let shmem = XPCShmem::allocate_task_self(
         0x1400000,
         i32::try_from(MAP_SHARED).expect("Must conv flags"),
     )?;
@@ -190,7 +190,7 @@ pub fn dumpjpcategory() -> Result<(usize, XPCShmem), XPCError> {
 }
 
 pub fn procinfo(pid: i64) -> Result<(usize, XPCShmem), XPCError> {
-    let shmem = XPCShmem::new_task_self(
+    let shmem = XPCShmem::allocate_task_self(
         0x1400000,
         i32::try_from(MAP_SHARED).expect("Must conv flags"),
     )?;

--- a/launchk/src/tui/omnibox/view.rs
+++ b/launchk/src/tui/omnibox/view.rs
@@ -339,7 +339,7 @@ impl OmniboxView {
 impl View for OmniboxView {
     fn draw(&self, printer: &Printer<'_, '_>) {
         self.draw_command_header(printer);
-        self.draw_job_type_filter(printer);
+        self.draw_job_type_filter(printer).expect("Must draw");
     }
 
     fn layout(&mut self, sz: Vec2) {

--- a/launchk/src/tui/omnibox/view.rs
+++ b/launchk/src/tui/omnibox/view.rs
@@ -1,6 +1,5 @@
-use std::cell::RefCell;
 use std::sync::mpsc::{channel, Receiver, Sender};
-use std::sync::{Arc, RwLock, TryLockResult};
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use tokio::runtime::Handle;

--- a/launchk/src/tui/service_list/view.rs
+++ b/launchk/src/tui/service_list/view.rs
@@ -1,7 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::ptr::slice_from_raw_parts;
-use std::rc::Rc;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;

--- a/launchk/src/tui/table/column_sizer.rs
+++ b/launchk/src/tui/table/column_sizer.rs
@@ -1,5 +1,4 @@
-use std::{cell::Cell, collections::HashMap, sync::Arc};
-use std::sync::atomic::AtomicUsize;
+use std::{collections::HashMap, sync::Arc};
 use std::sync::RwLock;
 
 /// Width oriented column sizing utility

--- a/launchk/src/tui/table/column_sizer.rs
+++ b/launchk/src/tui/table/column_sizer.rs
@@ -18,6 +18,7 @@ pub struct ColumnSizer {
     user_sizes_total: usize,
 }
 
+#[derive(Debug)]
 pub enum ColumnSizerError {
     UpdateError,
     ReadError,

--- a/launchk/src/tui/table/table_list_view.rs
+++ b/launchk/src/tui/table/table_list_view.rs
@@ -160,7 +160,7 @@ impl<T: 'static + TableListItem + Send + Sync> ViewWrapper for TableListView<T> 
     }
 
     fn wrap_layout(&mut self, size: Vec2) {
-        self.column_sizer.update_x(size.x);
+        self.column_sizer.update_x(size.x).expect("Must update");
         self.linear_layout.layout(size);
     }
 }

--- a/launchk/src/tui/table/table_list_view.rs
+++ b/launchk/src/tui/table/table_list_view.rs
@@ -1,7 +1,5 @@
-use std::cell::RefCell;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
-use std::rc::Rc;
 
 use std::collections::hash_map::DefaultHasher;
 use std::sync::{Arc, RwLock};
@@ -94,7 +92,7 @@ impl<T: 'static + TableListItem + Send + Sync> TableListView<T> {
 
         match self.last_hash.try_read() {
             Ok(lh) => {
-                if (*lh == hash) { return; }
+                if *lh == hash { return; }
             }
             _ => {}
         }

--- a/xpc-sys/Cargo.toml
+++ b/xpc-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xpc-sys"
 description = "Conveniently call routines with wrappers for xpc_pipe_routine() and go from Rust types to XPC objects and back!"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["David Stancu <dstancu@nyu.edu>"]
 license = "MIT"
 edition = "2018"
@@ -19,7 +19,7 @@ block = "0.1.6"
 lazy_static = "1.4.0"
 log = "0.4.20"
 bitflags = "2.4.0"
-libc = "0.2.147"
+libc = "0.2.172"
 mach2 = "0.4.2"
 
 [build-dependencies]

--- a/xpc-sys/Cargo.toml
+++ b/xpc-sys/Cargo.toml
@@ -20,6 +20,7 @@ lazy_static = "1.4.0"
 log = "0.4.20"
 bitflags = "2.4.0"
 libc = "0.2.147"
+mach2 = "0.4.2"
 
 [build-dependencies]
 bindgen = "0.69.1"

--- a/xpc-sys/build.rs
+++ b/xpc-sys/build.rs
@@ -27,7 +27,11 @@ fn main() {
         .header(bootstrap_path)
         // Filter the results to only relevant symbols
         .allowlist_function("^xpc_.*")
+        .allowlist_function("^dispatch.*")
+        .allowlist_function("^CF.*")
+        .allowlist_var("DISPATCH.*")
         .allowlist_var("^_xpc_.*")
+        .allowlist_var(("^XPC.*"))
         .blocklist_type("^mach.*")
         // This function began appearing as of macOS 14.4 SDK headers
         .blocklist_function("xpc_dictionary_set_mach_send")

--- a/xpc-sys/build.rs
+++ b/xpc-sys/build.rs
@@ -31,7 +31,7 @@ fn main() {
         .allowlist_function("^CF.*")
         .allowlist_var("DISPATCH.*")
         .allowlist_var("^_xpc_.*")
-        .allowlist_var(("^XPC.*"))
+        .allowlist_var("^XPC.*")
         .blocklist_type("^mach.*")
         // This function began appearing as of macOS 14.4 SDK headers
         .blocklist_function("xpc_dictionary_set_mach_send")

--- a/xpc-sys/build.rs
+++ b/xpc-sys/build.rs
@@ -28,12 +28,9 @@ fn main() {
         // Filter the results to only relevant symbols
         .allowlist_function("^xpc_.*")
         .allowlist_var("^_xpc_.*")
-        .allowlist_var("^bootstrap_port")
+        .blocklist_type("^mach.*")
         // This function began appearing as of macOS 14.4 SDK headers
         .blocklist_function("xpc_dictionary_set_mach_send")
-        // The following symbols should probably be in libc or mach2, but are not
-        .allowlist_function("^mach_port.*")
-        .allowlist_function("^vm_allocate")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))

--- a/xpc-sys/src/lib.rs
+++ b/xpc-sys/src/lib.rs
@@ -3,13 +3,19 @@
 #![allow(non_snake_case)]
 
 #[macro_use]
+extern crate bitflags;
+#[macro_use]
 extern crate lazy_static;
 
-#[macro_use]
-extern crate bitflags;
-
 pub use libc::MAP_SHARED;
-use libc::{geteuid, mach_task_self_, strerror, sysctlbyname, KERN_SUCCESS, MACH_PORT_NULL};
+use libc::{geteuid, strerror, sysctlbyname, KERN_SUCCESS, MACH_PORT_NULL};
+use mach2::bootstrap::bootstrap_port;
+use mach2::kern_return::kern_return_t;
+use mach2::mach_port::mach_port_deallocate;
+use mach2::message::mach_msg_type_number_t;
+use mach2::port::mach_port_t;
+use mach2::task::mach_ports_lookup;
+use mach2::traps::mach_task_self;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_long, c_void};
 use std::ptr::null_mut;
@@ -32,7 +38,6 @@ pub type xpc_pipe_t = *mut c_void;
 extern "C" {
     // Can decode i64 returned in "errors" for XPC responses
     pub fn xpc_strerror(err: c_int) -> *const c_char;
-    pub static errno: c_int;
 
     pub fn xpc_pipe_create_from_port(port: mach_port_t, flags: u64) -> xpc_pipe_t;
     pub fn xpc_pipe_routine_with_flags(
@@ -104,7 +109,7 @@ pub unsafe fn lookup_bootstrap_port() -> mach_port_t {
     let mut num_ports: mach_msg_type_number_t = 0;
     let mut found_ports: *mut mach_port_t = null_mut();
 
-    let kr: kern_return_t = mach_ports_lookup(mach_task_self_, &mut found_ports, &mut num_ports);
+    let kr: kern_return_t = mach_ports_lookup(mach_task_self(), &mut found_ports, &mut num_ports);
 
     if kr != KERN_SUCCESS as i32 {
         panic!("Unable to obtain Mach bootstrap port!");
@@ -124,7 +129,7 @@ pub unsafe fn lookup_bootstrap_port() -> mach_port_t {
 
         log::debug!("Deallocating mach_port_t {}", port);
 
-        mach_port_deallocate(mach_task_self_, port);
+        mach_port_deallocate(mach_task_self(), port);
     }
 
     ret_port

--- a/xpc-sys/src/lib.rs
+++ b/xpc-sys/src/lib.rs
@@ -183,11 +183,3 @@ pub unsafe fn rs_sysctlbyname(name: &str) -> Result<String, String> {
 pub fn rs_geteuid() -> uid_t {
     unsafe { geteuid() }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/xpc-sys/src/objects/unix_fifo.rs
+++ b/xpc-sys/src/objects/unix_fifo.rs
@@ -1,4 +1,4 @@
-use libc::{mkfifo, mode_t, open, tmpnam, O_RDONLY, O_WRONLY};
+use libc::{__error, mkfifo, mode_t, open, tmpnam, O_RDONLY, O_WRONLY};
 use std::os::unix::prelude::RawFd;
 use std::{
     ffi::{CStr, CString},
@@ -8,7 +8,7 @@ use std::{
     ptr::null_mut,
 };
 
-use crate::{errno, rs_strerror};
+use crate::rs_strerror;
 
 /// A wrapper around a UNIX FIFO
 pub struct UnixFifo(pub CString);
@@ -62,7 +62,7 @@ impl UnixFifo {
         if err == 0 {
             Ok(())
         } else {
-            Err(rs_strerror(unsafe { errno }))
+            Err(rs_strerror(unsafe { *__error() }))
         }
     }
 }

--- a/xpc-sys/src/objects/xpc_dictionary.rs
+++ b/xpc-sys/src/objects/xpc_dictionary.rs
@@ -152,7 +152,7 @@ impl TryFrom<xpc_object_t> for XPCDictionary {
     /// related to passing in objects other than XPC_TYPE_DICTIONARY
     #[must_use]
     fn try_from(value: xpc_object_t) -> Result<XPCDictionary, XPCError> {
-        let obj: XPCObject = value.into();
+        let obj: XPCObject = unsafe { XPCObject::from_raw(value) };
         obj.try_into()
     }
 }
@@ -179,7 +179,7 @@ where
             }
         }
 
-        dict.into()
+        unsafe { XPCObject::from_raw(dict) }
     }
 }
 

--- a/xpc-sys/src/objects/xpc_dictionary.rs
+++ b/xpc-sys/src/objects/xpc_dictionary.rs
@@ -12,10 +12,11 @@ use crate::objects::xpc_error::XPCError::DictionaryError;
 use crate::objects::xpc_object::XPCObject;
 use crate::rs_strerror;
 use crate::{
-    errno, xpc_dictionary_apply, xpc_dictionary_create, xpc_dictionary_set_value, xpc_object_t,
+    xpc_dictionary_apply, xpc_dictionary_create, xpc_dictionary_set_value, xpc_object_t,
 };
 
 use block::ConcreteBlock;
+use libc::__error;
 
 /// A wrapper around Rust HashMap<String, Arc<XPCObject>> that can
 /// be Into<XPCObject>
@@ -120,7 +121,7 @@ impl TryFrom<&XPCObject> for XPCDictionary {
         } else {
             Err(DictionaryError(format!(
                 "xpc_dictionary_apply failed: {}",
-                rs_strerror(unsafe { errno })
+                rs_strerror(unsafe { *__error() })
             )))
         }
     }

--- a/xpc-sys/src/objects/xpc_dictionary.rs
+++ b/xpc-sys/src/objects/xpc_dictionary.rs
@@ -11,9 +11,7 @@ use crate::objects::xpc_error::XPCError;
 use crate::objects::xpc_error::XPCError::DictionaryError;
 use crate::objects::xpc_object::XPCObject;
 use crate::rs_strerror;
-use crate::{
-    xpc_dictionary_apply, xpc_dictionary_create, xpc_dictionary_set_value, xpc_object_t,
-};
+use crate::{xpc_dictionary_apply, xpc_dictionary_create, xpc_dictionary_set_value, xpc_object_t};
 
 use block::ConcreteBlock;
 use libc::__error;

--- a/xpc-sys/src/objects/xpc_object.rs
+++ b/xpc-sys/src/objects/xpc_object.rs
@@ -1,7 +1,11 @@
 use libc::c_int;
 
 use crate::objects::xpc_type::XPCType;
-use crate::{xpc_array_append_value, xpc_array_create, xpc_bool_create, xpc_copy, xpc_copy_description, xpc_double_create, xpc_fd_create, xpc_int64_create, xpc_mach_recv_create, xpc_mach_send_create, xpc_object_t, xpc_release, xpc_retain, xpc_string_create, xpc_uint64_create};
+use crate::{
+    xpc_array_append_value, xpc_array_create, xpc_bool_create, xpc_copy, xpc_copy_description,
+    xpc_double_create, xpc_fd_create, xpc_int64_create, xpc_mach_recv_create, xpc_mach_send_create,
+    xpc_object_t, xpc_release, xpc_retain, xpc_string_create, xpc_uint64_create,
+};
 use libc::mach_port_t;
 use std::ffi::{CStr, CString};
 use std::os::unix::prelude::RawFd;
@@ -221,7 +225,7 @@ impl Drop for XPCObject {
 
         if *ptr == null_mut() {
             log::info!("XPCObject xpc_object_t is NULL, not calling xpc_release()");
-            return 
+            return;
         }
 
         log::info!(

--- a/xpc-sys/src/objects/xpc_object.rs
+++ b/xpc-sys/src/objects/xpc_object.rs
@@ -1,11 +1,7 @@
 use libc::c_int;
 
 use crate::objects::xpc_type::XPCType;
-use crate::{
-    xpc_array_append_value, xpc_array_create, xpc_bool_create, xpc_copy, xpc_copy_description,
-    xpc_double_create, xpc_fd_create, xpc_int64_create, xpc_mach_recv_create, xpc_mach_send_create,
-    xpc_object_t, xpc_release, xpc_string_create, xpc_uint64_create,
-};
+use crate::{xpc_array_append_value, xpc_array_create, xpc_bool_create, xpc_copy, xpc_copy_description, xpc_double_create, xpc_fd_create, xpc_int64_create, xpc_mach_recv_create, xpc_mach_send_create, xpc_object_t, xpc_release, xpc_retain, xpc_string_create, xpc_uint64_create};
 use libc::mach_port_t;
 use std::ffi::{CStr, CString};
 use std::os::unix::prelude::RawFd;
@@ -23,6 +19,14 @@ unsafe impl Send for XPCObject {}
 unsafe impl Sync for XPCObject {}
 
 impl XPCObject {
+    pub unsafe fn from_raw(value: xpc_object_t) -> XPCObject {
+        Self::new(value)
+    }
+
+    pub unsafe fn from_raw_retain(value: xpc_object_t) -> XPCObject {
+        Self::new(xpc_retain(value))
+    }
+
     fn new(value: xpc_object_t) -> Self {
         let obj = Self(value, value.into());
 
@@ -101,11 +105,11 @@ impl fmt::Display for XPCObject {
     }
 }
 
-impl From<xpc_object_t> for XPCObject {
-    fn from(value: xpc_object_t) -> Self {
-        XPCObject::new(value)
-    }
-}
+// impl From<xpc_object_t> for XPCObject {
+//     fn from(value: xpc_object_t) -> Self {
+//         XPCObject::new(value)
+//     }
+// }
 
 impl From<i64> for XPCObject {
     /// Create XPCObject via xpc_int64_create

--- a/xpc-sys/src/objects/xpc_shmem.rs
+++ b/xpc-sys/src/objects/xpc_shmem.rs
@@ -94,7 +94,7 @@ mod tests {
     use crate::objects::xpc_object::XPCObject;
     use crate::objects::xpc_shmem::XPCShmem;
     use crate::traits::query_builder::QueryBuilder;
-    use crate::{dispatch_get_global_queue, xpc_connection_create, xpc_connection_create_from_endpoint, xpc_connection_resume, xpc_connection_send_message, xpc_connection_set_event_handler, xpc_connection_t, xpc_dictionary_get_string, xpc_endpoint_create, xpc_object_t, xpc_retain, xpc_shmem_map, DISPATCH_QUEUE_PRIORITY_HIGH};
+    use crate::{dispatch_get_global_queue, xpc_connection_create, xpc_connection_create_from_endpoint, xpc_connection_resume, xpc_connection_send_message, xpc_connection_set_event_handler, xpc_connection_t, xpc_endpoint_create, xpc_object_t, xpc_retain, xpc_shmem_map, DISPATCH_QUEUE_PRIORITY_HIGH};
     use block::ConcreteBlock;
     use libc::MAP_SHARED;
 

--- a/xpc-sys/src/objects/xpc_shmem.rs
+++ b/xpc-sys/src/objects/xpc_shmem.rs
@@ -25,13 +25,14 @@ unsafe impl Send for XPCShmem {}
 impl XPCShmem {
     pub fn from_xpc_object(value: XPCObject) -> XPCShmem {
         let mut region: *mut c_void = null_mut();
-        let size: mach_vm_size_t = unsafe { xpc_shmem_map(value.as_ptr(), &mut region) as mach_vm_size_t };
+        let size: mach_vm_size_t =
+            unsafe { xpc_shmem_map(value.as_ptr(), &mut region) as mach_vm_size_t };
 
         XPCShmem {
             task: None,
             region,
             size,
-            xpc_object: Arc::new(value)
+            xpc_object: Arc::new(value),
         }
     }
 
@@ -43,12 +44,16 @@ impl XPCShmem {
             task: None,
             region,
             size,
-            xpc_object: XPCObject::from_raw(value).into()
+            xpc_object: XPCObject::from_raw(value).into(),
         }
     }
 
     /// Allocate a region of memory of vm_size_t & flags, then wrap in a XPC Object
-    pub fn allocate(task: mach_port_t, size: mach_vm_size_t, flags: c_int) -> Result<XPCShmem, XPCError> {
+    pub fn allocate(
+        task: mach_port_t,
+        size: mach_vm_size_t,
+        flags: c_int,
+    ) -> Result<XPCShmem, XPCError> {
         let mut region: *mut c_void = null_mut();
         let err = unsafe {
             mach_vm_allocate(
@@ -62,9 +67,8 @@ impl XPCShmem {
         if err > 0 {
             Err(XPCError::IOError(rs_strerror(err)))
         } else {
-            let xpc_object: XPCObject = unsafe {
-                XPCObject::from_raw(xpc_shmem_create(region, size as usize))
-            };
+            let xpc_object: XPCObject =
+                unsafe { XPCObject::from_raw(xpc_shmem_create(region, size as usize)) };
 
             log::info!(
                 "XPCShmem new (region: {:p}, xpc_object_t {:p})",
@@ -96,7 +100,9 @@ impl From<XPCObject> for XPCShmem {
 
 impl From<&XPCObject> for XPCShmem {
     fn from(value: &XPCObject) -> Self {
-        unsafe { xpc_retain(value.as_ptr()); }
+        unsafe {
+            xpc_retain(value.as_ptr());
+        }
         Self::from_xpc_object(value.clone())
     }
 }
@@ -115,7 +121,13 @@ impl Drop for XPCShmem {
             xpc_object.as_ptr()
         );
 
-        let ok = unsafe { mach_vm_deallocate(task.unwrap_or(mach_task_self()), *region as mach_vm_address_t, *size) };
+        let ok = unsafe {
+            mach_vm_deallocate(
+                task.unwrap_or(mach_task_self()),
+                *region as mach_vm_address_t,
+                *size,
+            )
+        };
 
         if ok != 0 {
             panic!("shmem won't drop (vm_deallocate errno {})", ok);
@@ -129,7 +141,12 @@ mod tests {
     use crate::objects::xpc_object::XPCObject;
     use crate::objects::xpc_shmem::XPCShmem;
     use crate::traits::dict_builder::DictBuilder;
-    use crate::{dispatch_get_global_queue, xpc_connection_create, xpc_connection_create_from_endpoint, xpc_connection_resume, xpc_connection_send_message, xpc_connection_set_event_handler, xpc_connection_t, xpc_endpoint_create, xpc_object_t, xpc_retain, xpc_shmem_map, DISPATCH_QUEUE_PRIORITY_HIGH};
+    use crate::{
+        dispatch_get_global_queue, xpc_connection_create, xpc_connection_create_from_endpoint,
+        xpc_connection_resume, xpc_connection_send_message, xpc_connection_set_event_handler,
+        xpc_connection_t, xpc_endpoint_create, xpc_object_t, xpc_retain, xpc_shmem_map,
+        DISPATCH_QUEUE_PRIORITY_HIGH,
+    };
     use block::ConcreteBlock;
     use libc::MAP_SHARED;
 
@@ -140,7 +157,10 @@ mod tests {
     use std::slice::from_raw_parts;
     use std::sync::{mpsc, Arc};
 
-    fn activate_with_handler<F>(peer: xpc_connection_t, f: F) -> xpc_connection_t where F: Fn(xpc_object_t) + 'static {
+    fn activate_with_handler<F>(peer: xpc_connection_t, f: F) -> xpc_connection_t
+    where
+        F: Fn(xpc_object_t) + 'static,
+    {
         let block = ConcreteBlock::new(f);
         let block = block.copy();
         unsafe {
@@ -158,20 +178,19 @@ mod tests {
 
         // Pages aligned by 16k on aarch64 and 4k on amd64. If you pass a smaller number
         // you will get the minimum page size per alignment
-        let shmem = XPCShmem::allocate_task_self(16384, MAP_SHARED)
-            .expect("Must make shmem");
+        let shmem = XPCShmem::allocate_task_self(16384, MAP_SHARED).expect("Must make shmem");
 
         let shmem_slice = unsafe {
-            shmem.region.copy_from(nums.as_ptr() as *const c_void, nums.len());
+            shmem
+                .region
+                .copy_from(nums.as_ptr() as *const c_void, nums.len());
             from_raw_parts(shmem.region as *const u8, nums.len())
         };
 
         assert!(shmem_slice.to_vec().eq(&nums));
 
         // Make an anonymous XPC listener
-        let queue = unsafe {
-            dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH as isize, 0)
-        };
+        let queue = unsafe { dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH as isize, 0) };
 
         let peer = unsafe { xpc_connection_create(null(), queue) };
         let (tx, rx) = mpsc::channel::<XPCObject>();
@@ -180,10 +199,13 @@ mod tests {
         activate_with_handler(peer, move |object: xpc_object_t| {
             let closure_tx = tx.clone();
 
-            activate_with_handler(object as xpc_connection_t, move |recv: xpc_object_t| unsafe {
-                let rx_xpc = XPCObject::from_raw(xpc_retain(recv));
-                closure_tx.send(rx_xpc).expect("Must send")
-            });
+            activate_with_handler(
+                object as xpc_connection_t,
+                move |recv: xpc_object_t| unsafe {
+                    let rx_xpc = XPCObject::from_raw(xpc_retain(recv));
+                    closure_tx.send(rx_xpc).expect("Must send")
+                },
+            );
         });
 
         let endpoint = unsafe { xpc_endpoint_create(peer) };
@@ -204,19 +226,18 @@ mod tests {
         }
 
         // Read the same message back from the channel and assert the contents of the shmem
-        let recv: XPCDictionary = rx
-            .recv()
-            .expect("Must recv")
-            .try_into()
-            .expect("Must dict");
+        let recv: XPCDictionary = rx.recv().expect("Must recv").try_into().expect("Must dict");
 
         let rx_shmem: XPCShmem = recv.get(&["shmem"]).unwrap().deref().into();
 
         // Map region from handle
         let mut rx_shmem_region: *mut c_void = null_mut();
-        unsafe { xpc_shmem_map(rx_shmem.xpc_object.as_ptr(), &mut rx_shmem_region); }
+        unsafe {
+            xpc_shmem_map(rx_shmem.xpc_object.as_ptr(), &mut rx_shmem_region);
+        }
 
-        let rx_shmem_slice: &[u8] = unsafe { from_raw_parts(rx_shmem_region as *const _, nums.len()) };
+        let rx_shmem_slice: &[u8] =
+            unsafe { from_raw_parts(rx_shmem_region as *const _, nums.len()) };
 
         assert_eq!(rx_shmem_slice.to_vec(), nums);
     }

--- a/xpc-sys/src/objects/xpc_shmem.rs
+++ b/xpc-sys/src/objects/xpc_shmem.rs
@@ -39,8 +39,9 @@ impl XPCShmem {
         if err > 0 {
             Err(XPCError::IOError(rs_strerror(err)))
         } else {
-            let xpc_object: XPCObject =
-                unsafe { xpc_shmem_create(region, size as usize).into() };
+            let xpc_object: XPCObject = unsafe {
+                XPCObject::from_raw(xpc_shmem_create(region, size as usize))
+            };
 
             log::info!(
                 "XPCShmem new (region: {:p}, xpc_object_t {:p})",
@@ -84,5 +85,103 @@ impl Drop for XPCShmem {
         if ok != 0 {
             panic!("shmem won't drop (vm_deallocate errno {})", ok);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::objects::xpc_dictionary::XPCDictionary;
+    use crate::objects::xpc_object::XPCObject;
+    use crate::objects::xpc_shmem::XPCShmem;
+    use crate::traits::query_builder::QueryBuilder;
+    use crate::{dispatch_get_global_queue, xpc_connection_create, xpc_connection_create_from_endpoint, xpc_connection_resume, xpc_connection_send_message, xpc_connection_set_event_handler, xpc_connection_t, xpc_dictionary_get_string, xpc_endpoint_create, xpc_object_t, xpc_retain, xpc_shmem_map, DISPATCH_QUEUE_PRIORITY_HIGH};
+    use block::ConcreteBlock;
+    use libc::MAP_SHARED;
+
+    use std::convert::TryInto;
+    use std::ffi::c_void;
+    use std::ptr::{null, null_mut};
+    use std::slice::from_raw_parts;
+    use std::sync::mpsc;
+
+    fn activate_with_handler<F>(peer: xpc_connection_t, f: F) -> xpc_connection_t where F: Fn(xpc_object_t) + 'static {
+        let block = ConcreteBlock::new(f);
+        let block = block.copy();
+        unsafe {
+            xpc_connection_set_event_handler(peer, &*block as *const _ as *mut _);
+            xpc_connection_resume(peer);
+        }
+
+        peer
+    }
+
+    #[test]
+    fn shmem_self_trip() {
+        // Make a shmem with 0-127, check that it's there
+        let nums: Vec<u8> = (0..128).collect();
+
+        // Pages aligned by 16k on aarch64 and 4k on amd64. If you pass a smaller number
+        // you will get the minimum page size per alignment
+        let shmem = XPCShmem::new_task_self(16384, MAP_SHARED)
+            .expect("Must make shmem");
+
+        let shmem_slice = unsafe {
+            shmem.region.copy_from(nums.as_ptr() as *const c_void, nums.len());
+            from_raw_parts(shmem.region as *const u8, nums.len())
+        };
+
+        assert!(shmem_slice.to_vec().eq(&nums));
+
+        // Make an anonymous XPC listener
+        let queue = unsafe {
+            dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH as isize, 0)
+        };
+
+        let peer = unsafe { xpc_connection_create(null(), queue) };
+        let (tx, rx) = mpsc::channel::<XPCObject>();
+
+        // The outer handler receives an XPC connection, which when activated has the sent message
+        activate_with_handler(peer, move |object: xpc_object_t| {
+            let closure_tx = tx.clone();
+
+            activate_with_handler(object as xpc_connection_t, move |recv: xpc_object_t| unsafe {
+                let rx_xpc = XPCObject::from_raw(xpc_retain(recv));
+                closure_tx.send(rx_xpc).expect("Must send")
+            });
+        });
+
+        let endpoint = unsafe { xpc_endpoint_create(peer) };
+        let endpoint_peer = unsafe { xpc_connection_create_from_endpoint(endpoint) };
+
+        // ??? cannot call xpc_connection_resume/activate without a handler bound
+        activate_with_handler(endpoint_peer, move |object: xpc_object_t| {
+            log::info!("Endpoint peer RX: {:?}", object);
+        });
+
+        // Send XPC dictionary with a shmem field
+        let dict: XPCObject = XPCDictionary::new()
+            .entry("shmem", &shmem.xpc_object)
+            .into();
+
+        unsafe {
+            xpc_connection_send_message(endpoint_peer, xpc_retain(dict.as_ptr()));
+        }
+
+        // Read the same message back from the channel and assert the contents of the shmem
+        let recv: XPCDictionary = rx
+            .recv()
+            .expect("Must recv")
+            .try_into()
+            .expect("Must dict");
+
+        let rx_shmem = recv.get(&["shmem"]).unwrap();
+
+        // Map region from handle
+        let mut rx_shmem_region: *mut c_void = null_mut();
+        unsafe { xpc_shmem_map(rx_shmem.as_ptr(), &mut rx_shmem_region); }
+
+        let rx_shmem_slice: &[u8] = unsafe { from_raw_parts(rx_shmem_region as *const _, nums.len()) };
+
+        assert_eq!(rx_shmem_slice.to_vec(), nums);
     }
 }

--- a/xpc-sys/src/objects/xpc_type.rs
+++ b/xpc-sys/src/objects/xpc_type.rs
@@ -1,7 +1,8 @@
 use crate::{
     _xpc_type_array, _xpc_type_bool, _xpc_type_dictionary, _xpc_type_double, _xpc_type_fd,
-    _xpc_type_int64, _xpc_type_mach_recv, _xpc_type_mach_send, _xpc_type_s, _xpc_type_shmem,
-    _xpc_type_string, _xpc_type_uint64, xpc_get_type, xpc_object_t, xpc_type_get_name, xpc_type_t, _xpc_type_null,
+    _xpc_type_int64, _xpc_type_mach_recv, _xpc_type_mach_send, _xpc_type_null, _xpc_type_s,
+    _xpc_type_shmem, _xpc_type_string, _xpc_type_uint64, xpc_get_type, xpc_object_t,
+    xpc_type_get_name, xpc_type_t,
 };
 
 use crate::objects::xpc_error::XPCError;

--- a/xpc-sys/src/traits/dict_builder.rs
+++ b/xpc-sys/src/traits/dict_builder.rs
@@ -5,9 +5,9 @@ use crate::objects::xpc_object::MachPortType;
 use crate::objects::xpc_object::XPCObject;
 use mach2::port::mach_port_t;
 
-/// Builder methods for XPCDictionary to make querying easier
-pub trait QueryBuilder {
-    /// Add entry to query
+/// Builder methods for XPCDictionary
+pub trait DictBuilder {
+    /// Add entry
     fn entry<S: Into<String>, O: Into<XPCObject>>(self, key: S, value: O) -> XPCDictionary;
 
     /// Add entry if option is Some()
@@ -58,7 +58,7 @@ pub trait QueryBuilder {
     }
 }
 
-impl QueryBuilder for XPCDictionary {
+impl DictBuilder for XPCDictionary {
     fn entry<S: Into<String>, O: Into<XPCObject>>(mut self, key: S, value: O) -> XPCDictionary {
         let Self(hm) = &mut self;
         let xpc_object: XPCObject = value.into();

--- a/xpc-sys/src/traits/mod.rs
+++ b/xpc-sys/src/traits/mod.rs
@@ -1,3 +1,3 @@
-pub mod query_builder;
+pub mod dict_builder;
 pub mod xpc_pipeable;
 pub mod xpc_value;

--- a/xpc-sys/src/traits/query_builder.rs
+++ b/xpc-sys/src/traits/query_builder.rs
@@ -3,7 +3,7 @@ use crate::get_bootstrap_port;
 use crate::objects::xpc_dictionary::XPCDictionary;
 use crate::objects::xpc_object::MachPortType;
 use crate::objects::xpc_object::XPCObject;
-use libc::mach_port_t;
+use mach2::port::mach_port_t;
 
 /// Builder methods for XPCDictionary to make querying easier
 pub trait QueryBuilder {

--- a/xpc-sys/src/traits/xpc_pipeable.rs
+++ b/xpc-sys/src/traits/xpc_pipeable.rs
@@ -56,7 +56,7 @@ pub trait XPCPipeable {
 
     fn handle_pipe_routine(ptr: xpc_object_t, errno: i32) -> XPCPipeResult {
         if errno == 0 {
-            Ok(ptr.into())
+            Ok(unsafe { XPCObject::from_raw(ptr) })
         } else {
             Err(PipeError(rs_xpc_strerror(errno)))
         }

--- a/xpc-sys/src/traits/xpc_value.rs
+++ b/xpc-sys/src/traits/xpc_value.rs
@@ -14,8 +14,8 @@ use crate::{
 use crate::objects::xpc_error::XPCError;
 use crate::objects::xpc_error::XPCError::ValueError;
 use crate::objects::xpc_type::check_xpc_type;
-use std::sync::Arc;
 use mach2::port::mach_port_t;
+use std::sync::Arc;
 
 /// Implement to get data out of xpc_type_t and into
 /// a Rust native data type

--- a/xpc-sys/src/traits/xpc_value.rs
+++ b/xpc-sys/src/traits/xpc_value.rs
@@ -10,12 +10,12 @@ use crate::{
     xpc_mach_send_get_right, xpc_object_t, xpc_string_get_string_ptr, xpc_type_get_name,
     xpc_uint64_get_value,
 };
-use libc::mach_port_t;
 
 use crate::objects::xpc_error::XPCError;
 use crate::objects::xpc_error::XPCError::ValueError;
 use crate::objects::xpc_type::check_xpc_type;
 use std::sync::Arc;
+use mach2::port::mach_port_t;
 
 /// Implement to get data out of xpc_type_t and into
 /// a Rust native data type


### PR DESCRIPTION
#### Changes
- Use `mach2` crate instead of `libc` 
- XPCShmem
  - Test facade on roundtrip through XPC anonymous listener
  - Make API clearer for allocation vs wrapping an existing handle
- XPCObject
  - Deprecate wrapping an `xpc_object_t` with `Into` in lieu of unsafe fns `from_raw` and `from_raw_retain`
- Misc docs tweaks